### PR TITLE
내역 화면 기본 기능 구현하기

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,18 +7,10 @@
         <entry key="../../../../../../layout/compose-model-1658842195722.xml" value="0.25" />
         <entry key="../../../../../../layout/compose-model-1658880724753.xml" value="0.18703703703703703" />
         <entry key="../../../../../../layout/compose-model-1658909841325.xml" value="0.15329391891891891" />
-        <entry key="../../../../../layout/compose-model-1658985479670.xml" value="0.17863175675675674" />
-        <entry key="../../../../../layout/compose-model-1658987638015.xml" value="0.47314814814814815" />
-        <entry key="../../../../../layout/compose-model-1658989452258.xml" value="0.45" />
-        <entry key="../../../../../layout/compose-model-1658990347244.xml" value="0.12880067567567569" />
-        <entry key="../../../../../layout/compose-model-1658991605380.xml" value="1.0" />
-        <entry key="../../../../../layout/compose-model-1658993076863.xml" value="1.0" />
-        <entry key="../../../../../layout/compose-model-1658993632402.xml" value="0.25" />
-        <entry key="../../../../../layout/compose-model-1658995308664.xml" value="0.14527027027027026" />
-        <entry key="../../../../../layout/compose-model-1658998802638.xml" value="1.0" />
-        <entry key="../../../../../layout/compose-model-1658999368729.xml" value="0.25" />
-        <entry key="../../../../../layout/compose-model-1658999846490.xml" value="0.3310810810810811" />
-        <entry key="app/src/main/res/drawable/ic_calendar.xml" value="0.195" />
+        <entry key="../../../../../../layout/compose-model-1658930788936.xml" value="1.0" />
+        <entry key="../../../../../../layout/compose-model-1658930844727.xml" value="0.21748310810810811" />
+        <entry key="../../../../../../layout/compose-model-1658934784511.xml" value="0.335" />
+        <entry key="app/src/main/res/layout/date_picker.xml" value="0.13229166666666667" />
       </map>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,6 +10,9 @@
         <entry key="../../../../../../layout/compose-model-1658930788936.xml" value="1.0" />
         <entry key="../../../../../../layout/compose-model-1658930844727.xml" value="0.21748310810810811" />
         <entry key="../../../../../../layout/compose-model-1658934784511.xml" value="0.335" />
+        <entry key="../../../../../../layout/compose-model-1659015787311.xml" value="0.1" />
+        <entry key="../../../../../../layout/compose-model-1659016280617.xml" value="0.21666666666666667" />
+        <entry key="../../../../../../layout/compose-model-1659016374207.xml" value="1.0" />
         <entry key="app/src/main/res/layout/date_picker.xml" value="0.13229166666666667" />
       </map>
     </option>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -13,6 +13,7 @@
         <entry key="../../../../../../layout/compose-model-1659015787311.xml" value="0.1" />
         <entry key="../../../../../../layout/compose-model-1659016280617.xml" value="0.21666666666666667" />
         <entry key="../../../../../../layout/compose-model-1659016374207.xml" value="1.0" />
+        <entry key="../../../../../../layout/compose-model-1659025099667.xml" value="0.15076013513513514" />
         <entry key="app/src/main/res/layout/date_picker.xml" value="0.13229166666666667" />
       </map>
     </option>

--- a/app/src/main/java/com/seom/accountbook/mock/HistoryMockData.kt
+++ b/app/src/main/java/com/seom/accountbook/mock/HistoryMockData.kt
@@ -14,7 +14,7 @@ val histories = hashMapOf<String, List<History>>(
                     method = "현대카드",
                     categoryName = "미분류",
                     categoryColor = 0xFFECECEC,
-                    type = HistoryType.getHistoryType(it % 2)
+                    type = HistoryType.INCOME
                 )
             )
         }

--- a/app/src/main/java/com/seom/accountbook/model/common/Date.kt
+++ b/app/src/main/java/com/seom/accountbook/model/common/Date.kt
@@ -1,0 +1,6 @@
+package com.seom.accountbook.model.common
+
+data class Date(
+    val year: Int,
+    val month: Int
+)

--- a/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
@@ -1,22 +1,25 @@
 package com.seom.accountbook.ui.components
 
+import android.widget.NumberPicker
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
+import com.seom.accountbook.model.common.Date
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.format
-import com.seom.accountbook.util.ext.toYearAndMonth
 import kotlinx.coroutines.launch
 import java.util.*
 
@@ -27,29 +30,37 @@ import java.util.*
 @Composable
 fun DateAppBar(
     currentDate: Date, // 현재 선택된 날짜
-    onDateChange: (Date) -> Unit, // 선택된 날짜 변경 이벤트
+    onDateChange: (Int, Int) -> Unit, // 선택된 날짜 변경 이벤트
     children: @Composable () -> Unit
 ) {
 
-    val bottomSheetState = rememberBottomSheetScaffoldState(
-        bottomSheetState = BottomSheetState(BottomSheetValue.Collapsed)
-    )
+    val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
 
-    BottomSheetScaffold(
-        scaffoldState = bottomSheetState,
+    ModalBottomSheetLayout(
+        sheetState = bottomSheetState,
         sheetContent = {
-            Row() {
-                Text(text = "hello world")
-            }
-        },
-        sheetPeekHeight = 0.dp
+            DatePickerBottomSheet(
+                currentDate = currentDate,
+                onCloseBottomSheet = {
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                    }
+                },
+                onClickConfirmBtn = { year, month ->
+                    onDateChange(year, month)
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                    }
+                }
+            )
+        }
     ) {
         Scaffold(
             topBar = {
                 AppBar(currentDate = currentDate) {
                     coroutineScope.launch {
-                        bottomSheetState.bottomSheetState.expand()
+                        bottomSheetState.show()
                     }
                 }
             }
@@ -75,7 +86,7 @@ fun AppBar(
         ) {
             Image(painter = painterResource(id = R.drawable.ic_left), contentDescription = null)
             Text(
-                text = currentDate.toYearAndMonth(),
+                text = currentDate.format(),
                 style = MaterialTheme.typography.body1,
                 color = ColorPalette.Purple,
                 modifier = Modifier.clickable { onClickDate() }
@@ -87,7 +98,85 @@ fun AppBar(
 
 @Composable
 fun DatePickerBottomSheet(
-
+    currentDate: Date,
+    onCloseBottomSheet: () -> Unit,
+    onClickConfirmBtn: (Int, Int) -> Unit
 ) {
-    
+    var year = currentDate.year
+    var month = currentDate.month
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                start = 16.dp,
+                top = 20.dp,
+                bottom = 16.dp,
+                end = 16.dp
+            )
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "날짜 선택",
+                style = MaterialTheme.typography.body2,
+                color = ColorPalette.Purple,
+                fontWeight = FontWeight(700)
+            )
+            Image(
+                painter = painterResource(id = R.drawable.ic_close),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(ColorPalette.Purple),
+                modifier = Modifier.clickable {
+                    onCloseBottomSheet()
+                }
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            NumberPicker(
+                state = remember { mutableStateOf(year) },
+                range = 0..year,
+                onStateChanged = { year = it }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "년",
+                style = MaterialTheme.typography.caption,
+                color = ColorPalette.LightPurple
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            NumberPicker(
+                state = remember { mutableStateOf(month) },
+                range = 1..12,
+                onStateChanged = { month = it }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "월",
+                style = MaterialTheme.typography.caption,
+                color = ColorPalette.LightPurple
+            )
+        }
+        Button(
+            onClick = { onClickConfirmBtn(year, month) },
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(backgroundColor = ColorPalette.Yellow)
+        ) {
+            Text(
+                text = "조회",
+                style = MaterialTheme.typography.caption,
+                color = ColorPalette.White
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
@@ -1,14 +1,14 @@
 package com.seom.accountbook.ui.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -17,15 +17,52 @@ import com.seom.accountbook.R
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.format
 import com.seom.accountbook.util.ext.toYearAndMonth
+import kotlinx.coroutines.launch
 import java.util.*
 
 /**
  * 화면 상단에서 일자 변경이 가능한 app bar
  */
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun DateAppBar(
     currentDate: Date, // 현재 선택된 날짜
     onDateChange: (Date) -> Unit, // 선택된 날짜 변경 이벤트
+    children: @Composable () -> Unit
+) {
+
+    val bottomSheetState = rememberBottomSheetScaffoldState(
+        bottomSheetState = BottomSheetState(BottomSheetValue.Collapsed)
+    )
+    val coroutineScope = rememberCoroutineScope()
+
+    BottomSheetScaffold(
+        scaffoldState = bottomSheetState,
+        sheetContent = {
+            Row() {
+                Text(text = "hello world")
+            }
+        },
+        sheetPeekHeight = 0.dp
+    ) {
+        Scaffold(
+            topBar = {
+                AppBar(currentDate = currentDate) {
+                    coroutineScope.launch {
+                        bottomSheetState.bottomSheetState.expand()
+                    }
+                }
+            }
+        ) {
+            children()
+        }
+    }
+}
+
+@Composable
+fun AppBar(
+    currentDate: Date, // 현재 선택된 날짜
+    onClickDate: () -> Unit
 ) {
     Surface(
         modifier = Modifier
@@ -40,9 +77,17 @@ fun DateAppBar(
             Text(
                 text = currentDate.toYearAndMonth(),
                 style = MaterialTheme.typography.body1,
-                color = ColorPalette.Purple
+                color = ColorPalette.Purple,
+                modifier = Modifier.clickable { onClickDate() }
             )
             Image(painter = painterResource(id = R.drawable.ic_right), contentDescription = null)
         }
     }
+}
+
+@Composable
+fun DatePickerBottomSheet(
+
+) {
+    
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/NumberPicker.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/NumberPicker.kt
@@ -1,0 +1,161 @@
+package com.seom.accountbook.ui.components
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import java.lang.Math.abs
+import kotlin.math.roundToInt
+
+@Composable
+fun NumberPicker(
+    state: MutableState<Int>,
+    modifier: Modifier = Modifier,
+    range: IntRange? = null,
+    textStyle: TextStyle = LocalTextStyle.current,
+    onStateChanged: (Int) -> Unit = {},
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val numbersColumnHeight = 36.dp
+    val halvedNumbersColumnHeight = numbersColumnHeight / 2
+    val halvedNumbersColumnHeightPx = with(LocalDensity.current) { halvedNumbersColumnHeight.toPx() }
+
+    fun animatedStateValue(offset: Float): Int = state.value - (offset / halvedNumbersColumnHeightPx).toInt()
+
+    val animatedOffset = remember { Animatable(0f) }.apply {
+        if (range != null) {
+            val offsetRange = remember(state.value, range) {
+                val value = state.value
+                val first = -(range.last - value) * halvedNumbersColumnHeightPx
+                val last = -(range.first - value) * halvedNumbersColumnHeightPx
+                first..last
+            }
+            updateBounds(offsetRange.start, offsetRange.endInclusive)
+        }
+    }
+    val coercedAnimatedOffset = animatedOffset.value % halvedNumbersColumnHeightPx
+    val animatedStateValue = animatedStateValue(animatedOffset.value)
+
+    Column(
+        modifier = modifier
+            .wrapContentSize()
+            .draggable(
+                orientation = Orientation.Vertical,
+                state = rememberDraggableState { deltaY ->
+                    coroutineScope.launch {
+                        animatedOffset.snapTo(animatedOffset.value + deltaY)
+                    }
+                },
+                onDragStopped = { velocity ->
+                    coroutineScope.launch {
+                        val endValue = animatedOffset.fling(
+                            initialVelocity = velocity,
+                            animationSpec = exponentialDecay(frictionMultiplier = 20f),
+                            adjustTarget = { target ->
+                                val coercedTarget = target % halvedNumbersColumnHeightPx
+                                val coercedAnchors = listOf(-halvedNumbersColumnHeightPx, 0f, halvedNumbersColumnHeightPx)
+                                val coercedPoint = coercedAnchors.minByOrNull { abs(it - coercedTarget) }!!
+                                val base = halvedNumbersColumnHeightPx * (target / halvedNumbersColumnHeightPx).toInt()
+                                coercedPoint + base
+                            }
+                        ).endState.value
+
+                        state.value = animatedStateValue(endValue)
+                        onStateChanged(state.value)
+                        animatedOffset.snapTo(0f)
+                    }
+                }
+            )
+    ) {
+        val spacing = 4.dp
+
+        val arrowColor = MaterialTheme.colors.onSecondary.copy(alpha = ContentAlpha.disabled)
+
+//        Arrow(direction = ArrowDirection.UP, tint = arrowColor)
+
+        Spacer(modifier = Modifier.height(spacing))
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .offset { IntOffset(x = 0, y = coercedAnimatedOffset.roundToInt()) }
+        ) {
+            val baseLabelModifier = Modifier.align(Alignment.Center)
+            ProvideTextStyle(textStyle) {
+                Label(
+                    text = (animatedStateValue - 1).toString(),
+                    modifier = baseLabelModifier
+                        .offset(y = -halvedNumbersColumnHeight)
+                        .alpha(coercedAnimatedOffset / halvedNumbersColumnHeightPx)
+                )
+                Label(
+                    text = animatedStateValue.toString(),
+                    modifier = baseLabelModifier
+                        .alpha(1 - abs(coercedAnimatedOffset) / halvedNumbersColumnHeightPx)
+                )
+                Label(
+                    text = (animatedStateValue + 1).toString(),
+                    modifier = baseLabelModifier
+                        .offset(y = halvedNumbersColumnHeight)
+                        .alpha(-coercedAnimatedOffset / halvedNumbersColumnHeightPx)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(spacing))
+
+//        Arrow(direction = ArrowDirection.DOWN, tint = arrowColor)
+    }
+}
+
+@Composable
+private fun Label(text: String, modifier: Modifier) {
+    Text(
+        text = text,
+        modifier = modifier.pointerInput(Unit) {
+            detectTapGestures(onLongPress = {
+                // FIXME: Empty to disable text selection
+            })
+        }
+    )
+}
+
+private suspend fun Animatable<Float, AnimationVector1D>.fling(
+    initialVelocity: Float,
+    animationSpec: DecayAnimationSpec<Float>,
+    adjustTarget: ((Float) -> Float)?,
+    block: (Animatable<Float, AnimationVector1D>.() -> Unit)? = null,
+): AnimationResult<Float, AnimationVector1D> {
+    val targetValue = animationSpec.calculateTargetValue(value, initialVelocity)
+    val adjustedTarget = adjustTarget?.invoke(targetValue)
+
+    return if (adjustedTarget != null) {
+        animateTo(
+            targetValue = adjustedTarget,
+            initialVelocity = initialVelocity,
+            block = block
+        )
+    } else {
+        animateDecay(
+            initialVelocity = initialVelocity,
+            animationSpec = animationSpec,
+            block = block,
+        )
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/components/NumberPicker.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/NumberPicker.kt
@@ -7,10 +7,7 @@ import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -34,9 +31,11 @@ fun NumberPicker(
     val coroutineScope = rememberCoroutineScope()
     val numbersColumnHeight = 36.dp
     val halvedNumbersColumnHeight = numbersColumnHeight / 2
-    val halvedNumbersColumnHeightPx = with(LocalDensity.current) { halvedNumbersColumnHeight.toPx() }
+    val halvedNumbersColumnHeightPx =
+        with(LocalDensity.current) { halvedNumbersColumnHeight.toPx() }
 
-    fun animatedStateValue(offset: Float): Int = state.value - (offset / halvedNumbersColumnHeightPx).toInt()
+    fun animatedStateValue(offset: Float): Int =
+        state.value - (offset / halvedNumbersColumnHeightPx).toInt()
 
     val animatedOffset = remember { Animatable(0f) }.apply {
         if (range != null) {
@@ -69,9 +68,15 @@ fun NumberPicker(
                             animationSpec = exponentialDecay(frictionMultiplier = 20f),
                             adjustTarget = { target ->
                                 val coercedTarget = target % halvedNumbersColumnHeightPx
-                                val coercedAnchors = listOf(-halvedNumbersColumnHeightPx, 0f, halvedNumbersColumnHeightPx)
-                                val coercedPoint = coercedAnchors.minByOrNull { abs(it - coercedTarget) }!!
-                                val base = halvedNumbersColumnHeightPx * (target / halvedNumbersColumnHeightPx).toInt()
+                                val coercedAnchors = listOf(
+                                    -halvedNumbersColumnHeightPx,
+                                    0f,
+                                    halvedNumbersColumnHeightPx
+                                )
+                                val coercedPoint =
+                                    coercedAnchors.minByOrNull { abs(it - coercedTarget) }!!
+                                val base =
+                                    halvedNumbersColumnHeightPx * (target / halvedNumbersColumnHeightPx).toInt()
                                 coercedPoint + base
                             }
                         ).endState.value

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -52,6 +52,7 @@ fun HistoryScreen() {
             // 수입 / 지출 리스트
             HistoryList(
                 historyGroupedByDate = histories,
+                currentType = currentSelectedTab,
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -141,24 +142,29 @@ fun HistoryTypeItem(
 fun HistoryList(
     // TODO Key 를 String 으로 두는게 맞을까...
     historyGroupedByDate: Map<String, List<History>>,
+    currentType: HistoryType,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
         modifier = modifier
     ) {
         historyGroupedByDate.forEach { (date, histories) ->
-            item {
-                HistoryListHeader(date = date, income = 1000, outCome = 2000)
-            }
-            items(items = histories) { history ->
-                HistoryListItem(history = history)
-            }
-            item {
-                Divider(
-                    color = ColorPalette.LightPurple,
-                    thickness = 1.dp
-                )
-                Spacer(modifier = Modifier.height(16.dp))
+            val filteredHistories = histories.filter { it.type == currentType }
+
+            if (filteredHistories.isNotEmpty()) {
+                item {
+                    HistoryListHeader(date = date, income = 1000, outCome = 2000)
+                }
+                items(items = histories.filter { it.type == currentType }) { history ->
+                    HistoryListItem(history = history)
+                }
+                item {
+                    Divider(
+                        color = ColorPalette.LightPurple,
+                        thickness = 1.dp
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
             }
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -34,15 +34,7 @@ fun HistoryScreen() {
     var currentSelectedTab by remember { mutableStateOf(HistoryType.INCOME) }
     var currentDate by remember { mutableStateOf(Date()) }
 
-    Scaffold(
-        topBar = {
-            // 상단 날짜 tab
-            DateAppBar(
-                currentDate = currentDate,
-                onDateChange = { currentDate = it }
-            )
-        }
-    ) {
+    DateAppBar(currentDate = currentDate, onDateChange = {}) {
         Divider(
             color = ColorPalette.Purple,
             thickness = 2.dp

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -149,22 +149,24 @@ fun HistoryList(
         modifier = modifier
     ) {
         historyGroupedByDate.forEach { (date, histories) ->
-            val filteredHistories = histories.filter { it.type == currentType }
-
-            if (filteredHistories.isNotEmpty()) {
-                item {
-                    HistoryListHeader(date = date, income = 1000, outCome = 2000)
-                }
-                items(items = histories.filter { it.type == currentType }) { history ->
-                    HistoryListItem(history = history)
-                }
-                item {
-                    Divider(
-                        color = ColorPalette.LightPurple,
-                        thickness = 1.dp
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
+            item {
+                HistoryListHeader(
+                    date = date,
+                    income = histories.filter { it.type == HistoryType.INCOME }
+                        .sumOf { it.money },
+                    outCome = histories.filter { it.type == HistoryType.OUTCOME }
+                        .sumOf { it.money }
+                )
+            }
+            items(items = histories.filter { it.type == currentType }) { history ->
+                HistoryListItem(history = history)
+            }
+            item {
+                Divider(
+                    color = ColorPalette.LightPurple,
+                    thickness = 1.dp
+                )
+                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }
@@ -195,7 +197,7 @@ fun HistoryListHeader(
             color = ColorPalette.LightPurple
         )
         Text(
-            text = "수입 $income 지출 $outCome",
+            text = "수입 ${income}원 지출 ${outCome}원",
             style = MaterialTheme.typography.subtitle1,
             color = ColorPalette.LightPurple
         )

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
 import com.seom.accountbook.mock.histories
+import com.seom.accountbook.model.common.Date
 import com.seom.accountbook.model.history.History
 import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.components.DateAppBar
@@ -32,9 +33,20 @@ import java.util.*
 @Composable
 fun HistoryScreen() {
     var currentSelectedTab by remember { mutableStateOf(HistoryType.INCOME) }
-    var currentDate by remember { mutableStateOf(Date()) }
+    val date = Calendar.getInstance()
+    var currentDate by remember {
+        mutableStateOf(
+            Date(
+                year = date.get(Calendar.YEAR),
+                month = date.get(Calendar.MONTH)
+            )
+        )
+    }
 
-    DateAppBar(currentDate = currentDate, onDateChange = {}) {
+    DateAppBar(currentDate = currentDate, onDateChange = { year, month ->
+        // TODO 변경된 날짜에 맞는 데이터 요청
+        currentDate = Date(year = year, month = month)
+    }) {
         Divider(
             color = ColorPalette.Purple,
             thickness = 2.dp

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -33,19 +33,9 @@ import java.util.*
 @Composable
 fun HistoryScreen() {
     var currentSelectedTab by remember { mutableStateOf(HistoryType.INCOME) }
-    val date = Calendar.getInstance()
-    var currentDate by remember {
-        mutableStateOf(
-            Date(
-                year = date.get(Calendar.YEAR),
-                month = date.get(Calendar.MONTH)
-            )
-        )
-    }
 
-    DateAppBar(currentDate = currentDate, onDateChange = { year, month ->
+    DateAppBar(onDateChange = { date ->
         // TODO 변경된 날짜에 맞는 데이터 요청
-        currentDate = Date(year = year, month = month)
     }) {
         Divider(
             color = ColorPalette.Purple,

--- a/app/src/main/java/com/seom/accountbook/util/ext/CalendarExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/CalendarExtension.kt
@@ -1,0 +1,14 @@
+package com.seom.accountbook.util.ext
+
+import java.util.*
+
+/**
+ * Util Calendar 관련 extension
+ */
+
+fun Calendar.format(): String {
+    val year = this.get(Calendar.YEAR)
+    val month = this.get(Calendar.MONTH)
+
+    return "${year}년 ${month}월"
+}

--- a/app/src/main/java/com/seom/accountbook/util/ext/DateExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/DateExtension.kt
@@ -1,16 +1,10 @@
 package com.seom.accountbook.util.ext
 
-import java.text.SimpleDateFormat
-import java.time.format.DateTimeFormatter
-import java.util.*
+import com.seom.accountbook.model.common.Date
+
 
 /**
- * Date 관련 확장 함수
+ * curtom Date 관련 확장 함수
  */
 
-fun Date.format(pattern: String): String {
-    val formatter = SimpleDateFormat(pattern, Locale.getDefault())
-    return formatter.format(this)
-}
-
-fun Date.toYearAndMonth() = this.format("YYYY년 MM월")
+fun Date.format(): String = "${year}년 ${month}월"

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M18,5L5,18M18,18L5,5L18,18Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
### 📌 Summary
수입/지출 화면에서 제공되는 기본 UI 기능 구현
(UI 작동만)

### 🍿 Main Changes
- 상단 바의 날짜 클릭 시, 날짜를 변경할 수 있는 팝업 생성
- 상단 바의 오른쪽/왼쪽 화살표 클릭 시, 날짜 변경
- 수입/지출 탭 선택 시, 리스트를 선택적으로 보여주기
- 수입/지출 리스트의 일별 수입/지출 총 금액 보여주기

### 🔥 UseCase
<img width="460" alt="스크린샷 2022-07-29 오전 1 34 06" src="https://user-images.githubusercontent.com/22411296/181590918-59f05861-9ec8-436a-b8bc-9b97c0648347.png">

### 🛠 Related Issue
Closes #8