### PR TITLE
내역 화면 선택 모드 구현하기

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -16,6 +16,7 @@
         <entry key="../../../../../../layout/compose-model-1659025099667.xml" value="0.15076013513513514" />
         <entry key="../../../../../../layout/compose-model-1659025298471.xml" value="0.21666666666666667" />
         <entry key="../../../../../../layout/compose-model-1659028951450.xml" value="0.14695945945945946" />
+        <entry key="../../../../../../layout/compose-model-1659034331152.xml" value="0.20059121621621623" />
         <entry key="app/src/main/res/layout/date_picker.xml" value="0.13229166666666667" />
       </map>
     </option>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,6 +14,8 @@
         <entry key="../../../../../../layout/compose-model-1659016280617.xml" value="0.21666666666666667" />
         <entry key="../../../../../../layout/compose-model-1659016374207.xml" value="1.0" />
         <entry key="../../../../../../layout/compose-model-1659025099667.xml" value="0.15076013513513514" />
+        <entry key="../../../../../../layout/compose-model-1659025298471.xml" value="0.21666666666666667" />
+        <entry key="../../../../../../layout/compose-model-1659028951450.xml" value="0.14695945945945946" />
         <entry key="app/src/main/res/layout/date_picker.xml" value="0.13229166666666667" />
       </map>
     </option>

--- a/app/src/main/java/com/seom/accountbook/mock/HistoryMockData.kt
+++ b/app/src/main/java/com/seom/accountbook/mock/HistoryMockData.kt
@@ -23,7 +23,7 @@ val histories = hashMapOf<String, List<History>>(
         (0..20).forEach {
             this.add(
                 History(
-                    id = it,
+                    id = it + 20,
                     content = "content $it",
                     money = it * 1000,
                     method = "현대카드",

--- a/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
@@ -32,7 +32,8 @@ import java.util.*
 @Composable
 fun DateAppBar(
     onDateChange: (Date) -> Unit, // 선택된 날짜 변경 이벤트
-    children: @Composable () -> Unit
+    children: @Composable () -> Unit,
+    header: (@Composable () -> Unit)?,
 ) {
     val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
@@ -88,7 +89,7 @@ fun DateAppBar(
         }
     ) {
         Scaffold(
-            topBar = {
+            topBar = header ?: {
                 AppBar(
                     date = date,
                     onClickDate = {

--- a/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/DateAppBar.kt
@@ -34,6 +34,7 @@ fun DateAppBar(
     onDateChange: (Date) -> Unit, // 선택된 날짜 변경 이벤트
     children: @Composable () -> Unit,
     header: (@Composable () -> Unit)?,
+    actionButton: @Composable () -> Unit = {}
 ) {
     val bottomSheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
@@ -124,7 +125,8 @@ fun DateAppBar(
                         onChangeDate(newDate)
                     }
                 )
-            }
+            },
+            floatingActionButton = actionButton
         ) {
             children()
         }

--- a/app/src/main/java/com/seom/accountbook/ui/components/TwoButtonAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/TwoButtonAppBar.kt
@@ -21,25 +21,18 @@ import com.seom.accountbook.ui.theme.ColorPalette
 fun TwoButtonAppBar(
     leftIcon: @Composable () -> Unit,
     rightIcon: @Composable () -> Unit,
-    title: String,
-    children: @Composable () -> Unit
+    title: String
 ) {
-    Scaffold(
-        topBar = {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                leftIcon()
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.body1,
-                    color = ColorPalette.Purple
-                )
-                rightIcon()
-            }
-        }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        children()
+        leftIcon()
+        Text(
+            text = title,
+            style = MaterialTheme.typography.body1,
+            color = ColorPalette.Purple
+        )
+        rightIcon()
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/components/TwoButtonAppBar.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/components/TwoButtonAppBar.kt
@@ -1,0 +1,45 @@
+package com.seom.accountbook.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.theme.ColorPalette
+
+/**
+ * 양쪽에 버튼이 두 개 있는 appbar
+ */
+@Composable
+fun TwoButtonAppBar(
+    leftIcon: @Composable () -> Unit,
+    rightIcon: @Composable () -> Unit,
+    title: String,
+    children: @Composable () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                leftIcon()
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.body1,
+                    color = ColorPalette.Purple
+                )
+                rightIcon()
+            }
+        }
+    ) {
+        children()
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -76,6 +76,15 @@ fun HistoryScreen() {
                 title = "${selectedItem.size}개 선택"
             )
         }
+    }, actionButton = {
+        FloatingActionButton(
+            onClick = {
+                // TODO 내역 추가 화면으로 이동
+            },
+            backgroundColor = ColorPalette.Yellow
+        ) {
+            Image(painter = painterResource(id = R.drawable.ic_plus), contentDescription = null)
+        }
     })
 }
 

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -45,8 +45,6 @@ fun HistoryScreen() {
             onClickItem = {
                 if (selectedItem.isNullOrEmpty()) {
                     // TODO 내역 수정 화면으로 이동
-                } else {
-                    if (it in selectedItem) selectedItem.remove(it) else selectedItem.add(it)
                 }
             },
             onLongClickItem = {
@@ -218,6 +216,7 @@ fun HistoryList(
             items(items = histories.filter { it.type == currentType }) { history ->
                 HistoryListItem(
                     history = history,
+                    selected = history.id in selectedItem,
                     modifier = Modifier
                         .pointerInput(Unit) {
                             detectTapGestures(
@@ -273,11 +272,13 @@ fun HistoryListHeader(
 @Composable
 fun HistoryListItem(
     history: History,
+    selected: Boolean,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .background(if (selected) ColorPalette.White else Color.Transparent)
             .padding(
                 start = 16.dp,
                 end = 16.dp,
@@ -288,60 +289,71 @@ fun HistoryListItem(
             color = ColorPalette.Purple40,
             thickness = 1.dp
         )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
+            modifier = Modifier.padding(top = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                text = history.categoryName,
-                modifier = Modifier
-                    .widthIn(56.dp)
-                    .clip(RoundedCornerShape(999.dp))
-                    .background(Color(history.categoryColor))
-                    .padding(
-                        start = 8.dp,
-                        top = 4.dp,
-                        bottom = 4.dp,
-                        end = 8.dp
-                    ),
-                style = MaterialTheme.typography.subtitle2,
-                color = ColorPalette.White,
-                textAlign = TextAlign.Center
-            )
-            Text(
-                text = history.method,
-                style = MaterialTheme.typography.subtitle1,
-                color = ColorPalette.Purple,
-                textAlign = TextAlign.End,
-                modifier = Modifier
-                    .padding(top = 4.dp)
-            )
+            if (selected) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_checkbox_checked),
+                    contentDescription = null
+                )
+            }
+            Column(
+                modifier = Modifier.padding(start = 8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = history.categoryName,
+                        modifier = Modifier
+                            .widthIn(56.dp)
+                            .clip(RoundedCornerShape(999.dp))
+                            .background(Color(history.categoryColor))
+                            .padding(
+                                start = 8.dp,
+                                top = 4.dp,
+                                bottom = 4.dp,
+                                end = 8.dp
+                            ),
+                        style = MaterialTheme.typography.subtitle2,
+                        color = ColorPalette.White,
+                        textAlign = TextAlign.Center
+                    )
+                    Text(
+                        text = history.method,
+                        style = MaterialTheme.typography.subtitle1,
+                        color = ColorPalette.Purple,
+                        textAlign = TextAlign.End,
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = history.content,
+                        style = MaterialTheme.typography.caption,
+                        color = ColorPalette.Purple
+                    )
+                    Text(
+                        text = "${
+                            if (history.type == HistoryType.OUTCOME) -1 * history.money
+                            else history.money
+                        } 원",
+                        style = MaterialTheme.typography.body2,
+                        fontWeight = FontWeight(700),
+                        color = if (history.type == HistoryType.INCOME) ColorPalette.Green else ColorPalette.Red
+                    )
+                }
+            }
         }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = history.content,
-                style = MaterialTheme.typography.caption,
-                color = ColorPalette.Purple
-            )
-            Text(
-                text = "${
-                    if (history.type == HistoryType.OUTCOME) -1 * history.money
-                    else history.money
-                } 원",
-                style = MaterialTheme.typography.body2,
-                fontWeight = FontWeight(700),
-                color = if (history.type == HistoryType.INCOME) ColorPalette.Green else ColorPalette.Red
-            )
-        }
-
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -37,54 +37,48 @@ import java.util.*
 @Composable
 fun HistoryScreen() {
     val selectedItem = remember { mutableStateListOf<Int>() }
-
-    if (selectedItem.isNullOrEmpty()) {
-        DateAppBar(onDateChange = { date ->
-            // TODO 변경된 날짜에 맞는 데이터 요청
-        }, children = {
-            HistoryBody(
-                selectedItem = selectedItem,
-                onClickItem = {
-                    // TODO 아이템 수정 화면으로 이동
-                },
-                onLongClickItem = {
-                    selectedItem.add(it)
-                }
-            )
-        })
-    } else {
-        TwoButtonAppBar(
-            leftIcon = {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_back),
-                    contentDescription = null,
-                    modifier = Modifier.clickable {
-                        selectedItem.clear()
-                    }
-                )
-            },
-            rightIcon = {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_trash),
-                    contentDescription = null,
-                    modifier = Modifier.clickable {
-                        // TODO 선택된 내역 삭제 요청
-                    }
-                )
-            },
-            title = "${selectedItem.size}개 선택"
-        ) {
-            HistoryBody(
-                selectedItem = selectedItem,
-                onClickItem = {
-                    if (it in selectedItem) selectedItem.remove(it) else selectedItem.add(it)
-                },
-                onLongClickItem = {
+    DateAppBar(onDateChange = { date ->
+        // TODO 변경된 날짜에 맞는 데이터 요청
+    }, children = {
+        HistoryBody(
+            selectedItem = selectedItem,
+            onClickItem = {
+                if (selectedItem.isNullOrEmpty()) {
+                    // TODO 내역 수정 화면으로 이동
+                } else {
                     if (it in selectedItem) selectedItem.remove(it) else selectedItem.add(it)
                 }
+            },
+            onLongClickItem = {
+                if (it in selectedItem) selectedItem.remove(it) else selectedItem.add(
+                    it
+                )
+            })
+    }, header = if (selectedItem.isNullOrEmpty()) null else {
+        {
+            TwoButtonAppBar(
+                leftIcon = {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_back),
+                        contentDescription = null,
+                        modifier = Modifier.clickable {
+                            selectedItem.clear()
+                        }
+                    )
+                },
+                rightIcon = {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_trash),
+                        contentDescription = null,
+                        modifier = Modifier.clickable {
+                            // TODO 선택된 내역 삭제 요청
+                        }
+                    )
+                },
+                title = "${selectedItem.size}개 선택"
             )
         }
-    }
+    })
 }
 
 @Composable

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -309,7 +309,7 @@ fun HistoryListItem(
                 )
             }
             Column(
-                modifier = Modifier.padding(start = 8.dp)
+                modifier = Modifier.padding(start = 16.dp)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/res/drawable/ic_back.xml
+++ b/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8.57,7.425L4,11.999L8.571,16.571M18.857,12H4"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#524D90"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_checkbox_checked.xml
+++ b/app/src/main/res/drawable/ic_checkbox_checked.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4.653,1.714H19.347C20.126,1.714 20.874,2.024 21.425,2.575C21.976,3.126 22.286,3.874 22.286,4.653V19.347C22.286,20.126 21.976,20.874 21.425,21.425C20.874,21.976 20.126,22.286 19.347,22.286H4.653C3.874,22.286 3.126,21.976 2.575,21.425C2.024,20.874 1.714,20.126 1.714,19.347V4.653C1.714,3.874 2.024,3.126 2.575,2.575C3.126,2.024 3.874,1.714 4.653,1.714Z"
+      android:fillColor="#E75B3F"
+      android:fillType="evenOdd"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M7.592,12L10.531,14.939L16.408,9.061"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_plus.xml
+++ b/app/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+      android:fillColor="#ffffff"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_trash.xml
+++ b/app/src/main/res/drawable/ic_trash.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M4,5.143H20M9.714,8.571V17.714M14.286,8.571V17.714M6.286,5.143H17.714V18.857C17.714,19.463 17.473,20.045 17.045,20.473C16.616,20.902 16.035,21.143 15.429,21.143H8.571C7.965,21.143 7.384,20.902 6.955,20.473C6.527,20.045 6.286,19.463 6.286,18.857V5.143ZM12,2.857C12.577,2.857 13.132,3.075 13.555,3.467C13.978,3.859 14.237,4.396 14.28,4.971L14.286,5.143H9.714C9.714,4.537 9.955,3.955 10.384,3.527C10.812,3.098 11.394,2.857 12,2.857V2.857Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#E75B3F"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
### 📌 Summary
수입/지출 화면에서 아이템 롱클릭 시, 선택모드로 전환하고 삭제할 아이템을 선택할 수 있도록 구현
(UI 작동만)

### 🍿 Main Changes
- 아이템 롱클릭 시, 상단 앱바가 변경되어 선택된 아이템 개수 표시
- 아이템 롱클릭 시, 아이템 UI 변경
- 상단 앱바 왼쪽 버튼 클릭 시, 선택된 아이템 모두 선택 취소하고 선택모드 해제

### 🔥 UseCase
<img width="461" alt="스크린샷 2022-07-29 오전 4 03 58" src="https://user-images.githubusercontent.com/22411296/181617655-c0d296c0-15bb-4d55-bcaa-7be095a4c91a.png">

### 🛠 Related Issue
Closes #10