### PR TITLE
통계 화면 기본 UI 구성하기(graph 화면)

### DIFF
--- a/app/src/main/java/com/seom/accountbook/model/BaseCount.kt
+++ b/app/src/main/java/com/seom/accountbook/model/BaseCount.kt
@@ -1,0 +1,8 @@
+package com.seom.accountbook.model
+
+interface BaseCount {
+    val id: Int
+    val count: Long
+    val color: Long
+    val name: String
+}

--- a/app/src/main/java/com/seom/accountbook/model/graph/OutComeByCategory.kt
+++ b/app/src/main/java/com/seom/accountbook/model/graph/OutComeByCategory.kt
@@ -1,0 +1,10 @@
+package com.seom.accountbook.model.graph
+
+import com.seom.accountbook.model.BaseCount
+
+data class OutComeByCategory(
+    override val id: Int, // categoryId
+    override val name: String, // category 이름
+    override val color: Long, // category 색
+    override val count: Long // category 별 지출금액
+) : BaseCount

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -146,21 +146,6 @@ fun CircleGraphByRate(
             360f
         }
     }
-    val shift by transition.animateFloat(
-        transitionSpec = {
-            tween(
-                delayMillis = 500,
-                durationMillis = 900,
-                easing = CubicBezierEasing(0f, 0.75f, 0.35f, 0.85f)
-            )
-        }
-    ) { progress ->
-        if (progress == AnimatedCircleProgress.START) {
-            0f
-        } else {
-            30f
-        }
-    }
 
     Canvas(modifier) {
         val innerRadius = (size.minDimension - stroke.width) / 2

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -1,9 +1,34 @@
 package com.seom.accountbook.ui.screen.graph
 
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.components.DateAppBar
+import com.seom.accountbook.ui.screen.calendar.CalendarContainer
+import com.seom.accountbook.ui.screen.calendar.RowData
+import com.seom.accountbook.ui.theme.ColorPalette
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun GraphScreen() {
-    Text(text = "graph")
+    DateAppBar(
+        onDateChange = {
+
+        },
+        children = {
+            Column {
+                Divider(
+                    color = ColorPalette.Purple,
+                    thickness = 1.dp
+                )
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -2,18 +2,19 @@ package com.seom.accountbook.ui.screen.graph
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.ui.components.DateAppBar
 import com.seom.accountbook.ui.screen.calendar.CalendarContainer
 import com.seom.accountbook.ui.screen.calendar.RowData
 import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.util.ext.toMoney
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -28,7 +29,34 @@ fun GraphScreen() {
                     color = ColorPalette.Purple,
                     thickness = 1.dp
                 )
+                TopRow(totalCount = 834640)
+                Divider(
+                    color = ColorPalette.LightPurple,
+                    thickness = 1.dp
+                )
             }
         }
     )
+}
+
+@Composable
+fun TopRow(
+    totalCount: Int
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, top = 9.dp, end = 16.dp, bottom = 9.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "이번 달 총 지출 금액",
+            style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
+        )
+        Text(
+            text = totalCount.toMoney(),
+            style = MaterialTheme.typography.caption.copy(color = ColorPalette.Red)
+        )
+    }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -2,19 +2,63 @@ package com.seom.accountbook.ui.screen.graph
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.VectorProperty
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.seom.accountbook.model.BaseCount
+import com.seom.accountbook.model.graph.OutComeByCategory
 import com.seom.accountbook.ui.components.DateAppBar
 import com.seom.accountbook.ui.screen.calendar.CalendarContainer
 import com.seom.accountbook.ui.screen.calendar.RowData
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.toMoney
+
+val mockData = listOf(
+    OutComeByCategory(id = 0, name = "생활", color = 0xFF4A6CC3, count = 536460),
+    OutComeByCategory(
+        id = 1,
+        name = "의료/건강",
+        color = 0xFF6ED5EB,
+        count = 125300
+    ),
+    OutComeByCategory(
+        id = 2,
+        name = "쇼핑/뷰티",
+        color = 0xFF4CB8B8,
+        count = 56000
+    ),
+    OutComeByCategory(id = 3, name = "교통", color = 0xFF94D3CC, count = 45340),
+    OutComeByCategory(id = 4, name = "식비", color = 0xFF4CA1DE, count = 40540),
+    OutComeByCategory(
+        id = 5,
+        name = "문화/여가",
+        color = 0xFFD092E2,
+        count = 20800
+    ),
+    OutComeByCategory(id = 6, name = "미분류", color = 0xFF817DCE, count = 10200)
+)
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -34,6 +78,16 @@ fun GraphScreen() {
                     color = ColorPalette.LightPurple,
                     thickness = 1.dp
                 )
+                Spacer(modifier = Modifier.height(24.dp))
+                CircleGraphByRate(
+                    date = mockData,
+                    totalCount = 834640,
+                    modifier = Modifier
+                        .height(254.dp)
+                        .fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                CategoryList(data = mockData, totalCount = 834640)
             }
         }
     )
@@ -58,5 +112,141 @@ fun TopRow(
             text = totalCount.toMoney(),
             style = MaterialTheme.typography.caption.copy(color = ColorPalette.Red)
         )
+    }
+}
+
+private const val DividerLengthInDegrees = 1.8f
+
+private enum class AnimatedCircleProgress { START, END }
+
+@Composable
+fun CircleGraphByRate(
+    date: List<BaseCount>,
+    totalCount: Long,
+    modifier: Modifier = Modifier
+) {
+    val currentState = remember {
+        MutableTransitionState(AnimatedCircleProgress.START)
+            .apply { targetState = AnimatedCircleProgress.END }
+    }
+    val stroke = with(LocalDensity.current) { Stroke(45.dp.toPx()) }
+    val transition = updateTransition(currentState)
+    val angleOffset by transition.animateFloat(
+        transitionSpec = {
+            tween(
+                delayMillis = 500,
+                durationMillis = 900,
+                easing = LinearOutSlowInEasing
+            )
+        }
+    ) { progress ->
+        if (progress == AnimatedCircleProgress.START) {
+            0f
+        } else {
+            360f
+        }
+    }
+    val shift by transition.animateFloat(
+        transitionSpec = {
+            tween(
+                delayMillis = 500,
+                durationMillis = 900,
+                easing = CubicBezierEasing(0f, 0.75f, 0.35f, 0.85f)
+            )
+        }
+    ) { progress ->
+        if (progress == AnimatedCircleProgress.START) {
+            0f
+        } else {
+            30f
+        }
+    }
+
+    Canvas(modifier) {
+        val innerRadius = (size.minDimension - stroke.width) / 2
+        val halfSize = size / 2.0f
+        val topLeft = Offset(
+            halfSize.width - innerRadius,
+            halfSize.height - innerRadius
+        )
+        val size = Size(innerRadius * 2, innerRadius * 2)
+        var startAngle = -90f
+        date.forEachIndexed { index, rate ->
+            val sweep = (rate.count / totalCount.toFloat()) * angleOffset
+            drawArc(
+                color = Color(rate.color),
+                startAngle = startAngle + DividerLengthInDegrees / 2,
+                sweepAngle = sweep - DividerLengthInDegrees,
+                topLeft = topLeft,
+                size = size,
+                useCenter = false,
+                style = stroke
+            )
+            startAngle += sweep
+        }
+    }
+}
+
+@Composable
+fun CategoryList(
+    data: List<OutComeByCategory>,
+    totalCount: Long
+) {
+    LazyColumn(
+    ) {
+        items(items = data) { row ->
+            CategoryOutComeItem(data = row, totalCount = totalCount)
+        }
+        item {
+            Divider(
+                color = ColorPalette.LightPurple,
+                thickness = 1.dp
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+        }
+    }
+}
+
+@Composable
+fun CategoryOutComeItem(
+    data: OutComeByCategory,
+    totalCount: Long
+) {
+    Column(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = data.name,
+                    style = MaterialTheme.typography.subtitle2.copy(
+                        fontWeight = FontWeight(700),
+                        color = ColorPalette.White
+                    ),
+                    modifier = Modifier
+                        .widthIn(56.dp)
+                        .clip(RoundedCornerShape(999.dp))
+                        .background(Color(data.color))
+                        .padding(start = 8.dp, top = 4.dp, end = 8.dp, bottom = 4.dp),
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = data.count.toMoney(),
+                    style = MaterialTheme.typography.caption.copy(fontWeight = FontWeight(500), color = ColorPalette.Purple),
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+            Text(
+                text = "${((data.count / totalCount.toFloat()) * 100).toInt().toString()}%",
+                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
+            )
+        }
+        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
     }
 }

--- a/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
@@ -1,0 +1,4 @@
+package com.seom.accountbook.util.ext
+import java.text.DecimalFormat
+
+fun Long.toMoney() = formatter.format(this)


### PR DESCRIPTION
### 📌 Summary
하단 bottom navigation tab에서 통계 클릭 시 보이는 화면(graph화면)의 기본 UI 구성하기

### 🍿 Main Changes
- [x] 앱 타이틀 클릭 시, 연도와 월 선택 기능 구현
- [x] 앱 상단 화살표 클릭 시, 이전/다음 달로 이동
------------------------
- [x] 상단에 총 지출 금액 표시하기
- [x] 원 그래프 애니메이션으로 그리기
- [x] 원 그래프 데이터 비율에 따라 다르게 그려주기
- [x] 하단의 카테고리별 지출 금액 표시해주기
   -> 카테고리가 많아질 경우를 생각해 LazyColumn 사용해서 표현

### 🔥 UseCase
<img width="468" alt="스크린샷 2022-07-30 오후 1 05 18" src="https://user-images.githubusercontent.com/22411296/181871774-ab64fc11-a5d7-452e-a291-4d97daa3506c.png">

### 🛠 Related Issue
Closes #16