### PR TITLE
특정 카테고리별 지출 화면 기본 UI 구성하기(detail 화면)

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,6 +22,7 @@
         <entry key="../../../../../../layout/compose-model-1659051994718.xml" value="0.1" />
         <entry key="../../../../../../layout/compose-model-1659079614511.xml" value="0.12037037037037036" />
         <entry key="../../../../../../layout/compose-model-1659086063833.xml" value="0.1" />
+        <entry key="../../../../../../layout/compose-model-1659169483455.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/background_category_spinner.xml" value="0.1" />
         <entry key="app/src/main/res/layout/date_picker.xml" value="0.13229166666666667" />
         <entry key="app/src/main/res/layout/header_category_option.xml" value="0.22395833333333334" />

--- a/app/src/main/java/com/seom/accountbook/AccountDestination.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountDestination.kt
@@ -20,14 +20,14 @@ object History : AccountDestination {
 }
 
 object Post : AccountDestination {
-    override val icon = R.drawable.ic_settings
+    override val icon = R.drawable.ic_history
     override val route = "post"
-    override val title = "설정"
+    override val title = "작성"
     override val group = "history"
     const val postIdArg = "post_id"
     val routeWithArgs = "${route}/{${postIdArg}}"
     val arguments = listOf(
-        navArgument(postIdArg){ type = NavType.StringType }
+        navArgument(postIdArg) { type = NavType.StringType }
     )
 }
 
@@ -43,6 +43,18 @@ object Graph : AccountDestination {
     override val route = "graph"
     override val title = "통계"
     override val group = "graph"
+}
+
+object Detail : AccountDestination {
+    override val icon = R.drawable.ic_graph
+    override val route = "detail"
+    override val title = "상세"
+    override val group = "graph"
+    const val categoryIdArgs = "category_id"
+    val routeWithArgs = "${Detail.route}/{${categoryIdArgs}}"
+    val arguments = listOf(
+        navArgument(categoryIdArgs) { type = NavType.StringType }
+    )
 }
 
 object Setting : AccountDestination {

--- a/app/src/main/java/com/seom/accountbook/model/graph/OutComeByMonth.kt
+++ b/app/src/main/java/com/seom/accountbook/model/graph/OutComeByMonth.kt
@@ -1,0 +1,10 @@
+package com.seom.accountbook.model.graph
+
+import com.seom.accountbook.model.BaseCount
+
+data class OutComeByMonth(
+    override val id: Int,
+    override val count: Long, // 월별 지출
+    override val color: Long,
+    override val name: String // 월
+) : BaseCount

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
@@ -1,25 +1,79 @@
 package com.seom.accountbook.ui.screen.detail
 
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.seom.accountbook.R
+import com.seom.accountbook.model.BaseCount
 import com.seom.accountbook.model.category.Category
+import com.seom.accountbook.model.graph.OutComeByMonth
 import com.seom.accountbook.model.method.Method
 import com.seom.accountbook.ui.components.OneButtonAppBar
 import com.seom.accountbook.ui.screen.post.PostBody
 import com.seom.accountbook.ui.screen.post.PostTopTab
 import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.util.ext.toMoney
 import kotlinx.coroutines.launch
+
+val mockData = listOf(
+    OutComeByMonth(
+        id = 0,
+        count = 509637,
+        color = 0xFF524D90,
+        name = "2"
+    ),
+    OutComeByMonth(
+        id = 1,
+        count = 563283,
+        color = 0xFFA79FCB,
+        name = "3"
+    ),
+    OutComeByMonth(
+        id = 2,
+        count = 590106,
+        color = 0xFFE75B3F,
+        name = "4"
+    ),
+    OutComeByMonth(
+        id = 3,
+        count = 643752,
+        color = 0xFFF5B853,
+        name = "5"
+    ),
+    OutComeByMonth(
+        id = 4,
+        count = 568647,
+        color = 0xFF4EAABA,
+        name = "6"
+    ),
+    OutComeByMonth(
+        id = 5,
+        count = 536460,
+        color = 0xFFA79FCB,
+        name = "7"
+    )
+)
 
 @Composable
 fun DetailScreen(
@@ -44,6 +98,106 @@ fun DetailScreen(
                 color = ColorPalette.Purple,
                 thickness = 1.dp
             )
+            LinearGraph(
+                data = mockData,
+                modifier = Modifier.fillMaxWidth(),
+                backgroundColor = ColorPalette.White,
+                lineColor = Brush.verticalGradient(
+                    colors = listOf(
+                        ColorPalette.LightPurple,
+                        ColorPalette.Purple
+                    )
+                ),
+                primaryTextColor = ColorPalette.Purple,
+                secondaryTextColor = ColorPalette.LightPurple
+            )
+            Divider(
+                color = ColorPalette.LightPurple,
+                thickness = 1.dp
+            )
+        }
+    }
+}
+
+val blockNum = 6
+val linearGraphPadding = 80f
+
+@Composable
+fun LinearGraph(
+    data: List<BaseCount>,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color, // 배경 색
+    lineColor: Brush, // 선 색
+    primaryTextColor: Color, // 강조 글자 색
+    secondaryTextColor: Color // 일반 글자 색
+) {
+    Column(
+        modifier = Modifier
+            .height(130.dp)
+            .background(backgroundColor)
+            .padding(7.dp)
+    ) {
+        Canvas(
+            modifier
+                .weight(1f)
+                .padding(top = 40.dp, bottom = 40.dp)
+        ) {
+            val canvasWidth = size.width
+            val canvasHeight = size.height
+
+            val minValue = data.minOf { it.count }
+            val maxValue = data.maxOf { it.count }
+            val diff = (maxValue - minValue)
+
+            val blockWidth = canvasWidth / (blockNum * 2)
+            val pointX = data.mapIndexed { index, row -> (blockWidth) * (index * 2 + 1) }
+            val pointY =
+                data.map { canvasHeight - (it.count - minValue) / (diff / canvasHeight) }
+
+            for (index in 1 until data.size) {
+                val start = Offset(x = pointX[index], y = pointY[index])
+                val end = Offset(x = pointX[index - 1], y = pointY[index - 1])
+                drawLine(
+                    start = start,
+                    end = end,
+                    brush = lineColor,
+                    strokeWidth = (2.0).toFloat().dp.toPx()
+                )
+            }
+
+            data.forEachIndexed { index, row ->
+                drawIntoCanvas {
+                    it.nativeCanvas.drawText(
+                        row.count.toMoney(),
+                        pointX[index],
+                        pointY[index] - (8.sp).toPx(),
+                        Paint().apply {
+                            textSize = (10.sp).toPx()
+                            color =
+                                (if (index == data.size - 1) primaryTextColor else secondaryTextColor).toArgb()
+                            typeface =
+                                Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+                            textAlign = Paint.Align.CENTER
+                        }
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            data.forEachIndexed { index, row ->
+                Text(
+                    text = row.name,
+                    style = MaterialTheme.typography.subtitle1.copy(
+                        fontWeight = FontWeight(700),
+                        color = if (index == data.size - 1) primaryTextColor else secondaryTextColor
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
@@ -1,12 +1,49 @@
 package com.seom.accountbook.ui.screen.detail
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.R
+import com.seom.accountbook.model.category.Category
+import com.seom.accountbook.model.method.Method
+import com.seom.accountbook.ui.components.OneButtonAppBar
+import com.seom.accountbook.ui.screen.post.PostBody
+import com.seom.accountbook.ui.screen.post.PostTopTab
+import com.seom.accountbook.ui.theme.ColorPalette
+import kotlinx.coroutines.launch
 
 @Composable
 fun DetailScreen(
     categoryId: String? = null,
     onBackButtonPressed: () -> Unit
 ) {
-    Text(text = "hello world")
+    val categoryName = "생활"
+
+    Scaffold(
+        topBar = {
+            OneButtonAppBar(title = categoryName) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_back),
+                    contentDescription = null,
+                    modifier = Modifier.clickable { onBackButtonPressed() })
+            }
+        }
+    ) {
+
+        Column {
+            Divider(
+                color = ColorPalette.Purple,
+                thickness = 1.dp
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
@@ -2,18 +2,16 @@ package com.seom.accountbook.ui.screen.detail
 
 import android.graphics.Paint
 import android.graphics.Typeface
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -22,14 +20,20 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.seom.accountbook.R
+import com.seom.accountbook.mock.histories
 import com.seom.accountbook.model.BaseCount
 import com.seom.accountbook.model.category.Category
 import com.seom.accountbook.model.graph.OutComeByMonth
+import com.seom.accountbook.model.history.History
+import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.model.method.Method
 import com.seom.accountbook.ui.components.OneButtonAppBar
+import com.seom.accountbook.ui.screen.history.HistoryList
+import com.seom.accountbook.ui.screen.history.HistoryListHeader
 import com.seom.accountbook.ui.screen.post.PostBody
 import com.seom.accountbook.ui.screen.post.PostTopTab
 import com.seom.accountbook.ui.theme.ColorPalette
@@ -115,6 +119,10 @@ fun DetailScreen(
                 color = ColorPalette.LightPurple,
                 thickness = 1.dp
             )
+            Spacer(modifier = Modifier.height(16.dp))
+            OutComeList(
+                historyGroupedByDate = histories
+            )
         }
     }
 }
@@ -197,6 +205,124 @@ fun LinearGraph(
                         color = if (index == data.size - 1) primaryTextColor else secondaryTextColor
                     )
                 )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun OutComeList(
+    // TODO Key 를 String 으로 두는게 맞을까...
+    historyGroupedByDate: Map<String, List<History>>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier
+    ) {
+        historyGroupedByDate.forEach { (date, histories) ->
+            stickyHeader {
+                HistoryListHeader(
+                    date = date,
+                    income = histories.filter { it.type == HistoryType.INCOME }
+                        .sumOf { it.money },
+                    outCome = histories.filter { it.type == HistoryType.OUTCOME }
+                        .sumOf { it.money }
+                )
+            }
+            items(items = histories) { history ->
+                OutComeListItem(
+                    history = history
+                )
+            }
+            item {
+                Divider(
+                    color = ColorPalette.LightPurple,
+                    thickness = 1.dp
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+fun OutComeListItem(
+    history: History,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Color.Transparent)
+            .padding(
+                start = 16.dp,
+                end = 16.dp,
+                bottom = 8.dp
+            )
+    ) {
+        Divider(
+            color = ColorPalette.Purple40,
+            thickness = 1.dp
+        )
+        Row(
+            modifier = Modifier.padding(top = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.padding(start = 16.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = history.categoryName,
+                        modifier = Modifier
+                            .widthIn(56.dp)
+                            .clip(RoundedCornerShape(999.dp))
+                            .background(Color(history.categoryColor))
+                            .padding(
+                                start = 8.dp,
+                                top = 4.dp,
+                                bottom = 4.dp,
+                                end = 8.dp
+                            ),
+                        style = MaterialTheme.typography.subtitle2,
+                        color = ColorPalette.White,
+                        textAlign = TextAlign.Center
+                    )
+                    Text(
+                        text = history.method,
+                        style = MaterialTheme.typography.subtitle1,
+                        color = ColorPalette.Purple,
+                        textAlign = TextAlign.End,
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = history.content,
+                        style = MaterialTheme.typography.caption,
+                        color = ColorPalette.Purple
+                    )
+                    Text(
+                        text = "${
+                            if (history.type == HistoryType.OUTCOME) -1 * history.money
+                            else history.money
+                        } 원",
+                        style = MaterialTheme.typography.body2,
+                        fontWeight = FontWeight(700),
+                        color = if (history.type == HistoryType.INCOME) ColorPalette.Green else ColorPalette.Red
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailScreen.kt
@@ -1,0 +1,12 @@
+package com.seom.accountbook.ui.screen.detail
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun DetailScreen(
+    categoryId: String? = null,
+    onBackButtonPressed: () -> Unit
+) {
+    Text(text = "hello world")
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RequiresApi
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -27,6 +28,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.seom.accountbook.Detail
 import com.seom.accountbook.model.BaseCount
 import com.seom.accountbook.model.graph.OutComeByCategory
 import com.seom.accountbook.ui.components.DateAppBar
@@ -62,7 +64,9 @@ val mockData = listOf(
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun GraphScreen() {
+fun GraphScreen(
+    onPushNavigate: (String, String) -> Unit
+) {
     DateAppBar(
         onDateChange = {
 
@@ -87,7 +91,10 @@ fun GraphScreen() {
                         .fillMaxWidth()
                 )
                 Spacer(modifier = Modifier.height(24.dp))
-                CategoryList(data = mockData, totalCount = 834640)
+                CategoryList(
+                    data = mockData,
+                    totalCount = 834640,
+                    onItemClick = { onPushNavigate(Detail.route, it.toString()) })
             }
         }
     )
@@ -175,12 +182,16 @@ fun CircleGraphByRate(
 @Composable
 fun CategoryList(
     data: List<OutComeByCategory>,
-    totalCount: Long
+    totalCount: Long,
+    onItemClick: (Int) -> Unit
 ) {
     LazyColumn(
     ) {
         items(items = data) { row ->
-            CategoryOutComeItem(data = row, totalCount = totalCount)
+            CategoryOutComeItem(
+                data = row,
+                totalCount = totalCount,
+                modifier = Modifier.clickable { onItemClick(row.id) })
         }
         item {
             Divider(
@@ -195,13 +206,16 @@ fun CategoryList(
 @Composable
 fun CategoryOutComeItem(
     data: OutComeByCategory,
-    totalCount: Long
+    totalCount: Long,
+    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+        modifier = modifier.padding(start = 16.dp, end = 16.dp)
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, bottom = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -223,7 +237,10 @@ fun CategoryOutComeItem(
                 )
                 Text(
                     text = data.count.toMoney(),
-                    style = MaterialTheme.typography.caption.copy(fontWeight = FontWeight(500), color = ColorPalette.Purple),
+                    style = MaterialTheme.typography.caption.copy(
+                        fontWeight = FontWeight(500),
+                        color = ColorPalette.Purple
+                    ),
                     modifier = Modifier.padding(start = 8.dp)
                 )
             }

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.seom.accountbook.*
 import com.seom.accountbook.ui.screen.calendar.CalendarScreen
+import com.seom.accountbook.ui.screen.detail.DetailScreen
 import com.seom.accountbook.ui.screen.graph.GraphScreen
 import com.seom.accountbook.ui.screen.history.HistoryScreen
 import com.seom.accountbook.ui.screen.post.PostScreen
@@ -39,7 +40,11 @@ fun AccountNavigationHost(
             )
         }
         composable(route = Graph.route) {
-            GraphScreen()
+            GraphScreen(
+                onPushNavigate = { route, argument ->
+                    navController.navigateSingleTop(route, argument)
+                }
+            )
         }
         composable(route = Setting.route) {
             SettingScreen()
@@ -56,6 +61,17 @@ fun AccountNavigationHost(
         }
         composable(route = Post.route) {
             PostScreen(
+                onBackButtonPressed = { navController.popBackStack() }
+            )
+        }
+
+        composable(
+            route = Detail.routeWithArgs,
+            arguments = Detail.arguments
+        ) { navBackStackEntry ->
+            val categoryId = navBackStackEntry.arguments?.getString(Detail.categoryIdArgs)
+            DetailScreen(
+                categoryId = categoryId,
                 onBackButtonPressed = { navController.popBackStack() }
             )
         }


### PR DESCRIPTION
### 📌 Summary
graph화면에서 카테고리 클릭 시, 해당 카테고리의 최근 6개월 간의 지출 내역을 보여주는 화면
기본 UI 구성하기
- Canvas를 사용하여 직접 구현
- 데이터는 아직 mock 데이터 사용

### 🍿 Main Changes
- [x] 상단 앱바를 구성하고, backbutton 클릭 시 이전화면으로 이동하기
- [x] 선형그래프 그리기
   - drawLine
   - drawText
- [x] 선형 그래프에 데이터 바인딩하기
- [x] 하단의 일별 지출 내역 표현해주기

### 🔥 UseCase
<img width="467" alt="스크린샷 2022-07-30 오후 7 00 55" src="https://user-images.githubusercontent.com/22411296/181905415-19f99b72-b868-4197-898b-72e40bd86ac5.png">

### 🛠 Related Issue
Closes #18