### PR TITLE
설정 화면 기본 UI 구성하기(setting 화면)

### DIFF
--- a/app/src/main/java/com/seom/accountbook/AccountDestination.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountDestination.kt
@@ -64,4 +64,36 @@ object Setting : AccountDestination {
     override val group = "setting"
 }
 
+object Method : AccountDestination {
+    override val icon = R.drawable.ic_settings
+    override val route = "method"
+    override val title = "결제수단"
+    override val group = "setting"
+
+    const val methodIdArgs = "method_id"
+    val routeWithArgs = "${route}/{${methodIdArgs}}"
+    val arguments = listOf(
+        navArgument(methodIdArgs) { type = NavType.StringType }
+    )
+}
+
+object Category : AccountDestination {
+    override val icon = R.drawable.ic_settings
+    override val route = "category"
+    override val title = "카테고리"
+    override val group = "setting"
+
+    const val categoryIdArgs = "category_id"
+    const val categoryTypeArgs = "category_type"
+    val routeWithArgs = "${route}/{${categoryTypeArgs}}"
+    val routeWithAllArgs = "${route}/{${categoryTypeArgs}}/{${categoryIdArgs}}"
+    val allArguments = listOf(
+        navArgument(categoryIdArgs) { type = NavType.StringType },
+        navArgument(categoryTypeArgs) { type = NavType.StringType }
+    )
+    val arguments = listOf(
+        navArgument(categoryTypeArgs) { type = NavType.StringType }
+    )
+}
+
 val accountBottomTabScreens = listOf(History, Calendar, Graph, Setting)

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -5,6 +5,7 @@ package com.seom.accountbook.ui.screen.setting
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -26,6 +27,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
 import com.seom.accountbook.model.category.Category
+import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.model.method.Method
 import com.seom.accountbook.ui.theme.ColorPalette
 
@@ -51,7 +53,9 @@ val incomeMock = listOf(
 )
 
 @Composable
-fun SettingScreen() {
+fun SettingScreen(
+    onPushNavigate: (String, String) -> Unit
+) {
     Scaffold(
         topBar = {
             Row(
@@ -77,22 +81,64 @@ fun SettingScreen() {
             LazyColumn {
                 stickyHeader { Header(title = "결제수단") }
                 items(items = methodMock) {
-                    MethodItem(method = it)
+                    MethodItem(method = it) {
+                        onPushNavigate(
+                            com.seom.accountbook.Method.route,
+                            it.toString()
+                        )
+                    }
                 }
-                item { AddItem(itemName = "결제수단") {} }
+                item {
+                    AddItem(itemName = "결제수단") {
+                        onPushNavigate(
+                            com.seom.accountbook.Method.route,
+                            ""
+                        )
+                    }
+                }
                 item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
                 stickyHeader { Header(title = "지출 카테고리") }
                 items(items = outcomeMock) {
-                    CategoryItem(category = it)
+                    CategoryItem(category = it) {
+                        onPushNavigate(
+                            com.seom.accountbook.Category.route,
+                            "${HistoryType.OUTCOME.type}/$it"
+                        )
+                    }
                 }
-                item { AddItem(itemName = "지출 카테고리") {} }
+                item {
+                    AddItem(itemName = "지출 카테고리") {
+                        onPushNavigate(
+                            com.seom.accountbook.Category.route,
+                            "${HistoryType.OUTCOME.type}"
+                        )
+                    }
+                }
                 item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
                 stickyHeader { Header(title = "수입 카테고리") }
                 items(items = incomeMock) {
-                    CategoryItem(category = it)
+                    CategoryItem(category = it) {
+                        onPushNavigate(
+                            com.seom.accountbook.Category.route,
+                            "${HistoryType.INCOME.type}/$it"
+                        )
+                    }
                 }
-                item { AddItem(itemName = "수입 카테고리") {} }
-                item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
+                item {
+                    AddItem(itemName = "수입 카테고리") {
+                        onPushNavigate(
+                            com.seom.accountbook.Category.route,
+                            "${HistoryType.INCOME.type}"
+                        )
+                    }
+                }
+                item {
+                    Divider(
+                        color = ColorPalette.LightPurple,
+                        thickness = 1.dp
+                    )
+                    Spacer(modifier = Modifier.height(40.dp))
+                }
             }
         }
     }
@@ -117,7 +163,8 @@ fun Header(
 
 @Composable
 fun MethodItem(
-    method: Method
+    method: Method,
+    onClickItem: (Int) -> Unit
 ) {
     Column(
         modifier = Modifier.padding(start = 16.dp, end = 16.dp)
@@ -126,7 +173,8 @@ fun MethodItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 12.dp, bottom = 12.dp),
+                .padding(top = 12.dp, bottom = 12.dp)
+                .clickable { onClickItem(method.id) },
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
@@ -139,7 +187,8 @@ fun MethodItem(
 
 @Composable
 fun CategoryItem(
-    category: Category
+    category: Category,
+    onClickItem: (Int) -> Unit
 ) {
     Column(
         modifier = Modifier.padding(start = 16.dp, end = 16.dp)
@@ -148,7 +197,8 @@ fun CategoryItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 12.dp, bottom = 12.dp),
+                .padding(top = 12.dp, bottom = 12.dp)
+                .clickable { onClickItem(category.id) },
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
@@ -185,7 +235,8 @@ fun AddItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 12.dp, bottom = 12.dp),
+                .padding(top = 12.dp, bottom = 12.dp)
+                .clickable { onClickAddButton() },
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -1,6 +1,12 @@
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package com.seom.accountbook.ui.screen.setting
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -8,8 +14,28 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.seom.accountbook.R
+import com.seom.accountbook.model.category.Category
+import com.seom.accountbook.model.method.Method
 import com.seom.accountbook.ui.theme.ColorPalette
+
+val methodMock = listOf(
+    Method(id = 0, name = "현대카드"),
+    Method(id = 1, name = "카카오뱅크 체크카드")
+)
+
+val outcomeMock = listOf(
+    Category(id = 0, name = "교통", categoryColor = 0xFF94D3CC),
+    Category(id = 0, name = "문화/여가", categoryColor = 0xFFD092E2),
+    Category(id = 0, name = "미분류", categoryColor = 0xFF817DCE),
+    Category(id = 0, name = "생활", categoryColor = 0xFF4A6CC3),
+    Category(id = 0, name = "쇼핑/뷰티", categoryColor = 0xFF4CB8B8),
+    Category(id = 0, name = "식비", categoryColor = 0xFF4CA1DE),
+    Category(id = 0, name = "의료/건강", categoryColor = 0xFF6ED5EB)
+)
 
 @Composable
 fun SettingScreen() {
@@ -33,6 +59,86 @@ fun SettingScreen() {
             Divider(
                 color = ColorPalette.Purple,
                 thickness = 1.dp
+            )
+
+            LazyColumn {
+                stickyHeader { Header(title = "결제수단") }
+                items(items = methodMock) {
+                    MethodItem(method = it)
+                }
+                item { AddItem(itemName = "결제수단") {} }
+                item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
+                stickyHeader { Header(title = "지출 카테고리") }
+                item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
+                stickyHeader { Header(title = "수입 카테고리") }
+                item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
+            }
+        }
+    }
+}
+
+@Composable
+fun Header(
+    title: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, top = 24.dp, end = 16.dp, bottom = 8.dp)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.body2.copy(color = ColorPalette.LightPurple)
+        )
+    }
+}
+
+@Composable
+fun MethodItem(
+    method: Method
+) {
+    Column(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+    ) {
+        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = method.name,
+                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
+            )
+        }
+    }
+}
+
+@Composable
+fun AddItem(
+    itemName: String,
+    onClickAddButton: () -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+    ) {
+        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp, bottom = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "$itemName 추가하기",
+                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
+            )
+            Image(
+                painter = painterResource(id = R.drawable.ic_plus),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(color = ColorPalette.Purple)
             )
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -4,9 +4,11 @@ package com.seom.accountbook.ui.screen.setting
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -14,8 +16,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
 import com.seom.accountbook.model.category.Category
@@ -35,6 +42,12 @@ val outcomeMock = listOf(
     Category(id = 0, name = "쇼핑/뷰티", categoryColor = 0xFF4CB8B8),
     Category(id = 0, name = "식비", categoryColor = 0xFF4CA1DE),
     Category(id = 0, name = "의료/건강", categoryColor = 0xFF6ED5EB)
+)
+
+val incomeMock = listOf(
+    Category(id = 0, name = "월급", categoryColor = 0xFF9BD182),
+    Category(id = 0, name = "용돈", categoryColor = 0xFFEDCF65),
+    Category(id = 0, name = "기타", categoryColor = 0xFFE29C4D)
 )
 
 @Composable
@@ -69,8 +82,16 @@ fun SettingScreen() {
                 item { AddItem(itemName = "결제수단") {} }
                 item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
                 stickyHeader { Header(title = "지출 카테고리") }
+                items(items = outcomeMock) {
+                    CategoryItem(category = it)
+                }
+                item { AddItem(itemName = "지출 카테고리") {} }
                 item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
                 stickyHeader { Header(title = "수입 카테고리") }
+                items(items = incomeMock) {
+                    CategoryItem(category = it)
+                }
+                item { AddItem(itemName = "수입 카테고리") {} }
                 item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
             }
         }
@@ -84,6 +105,7 @@ fun Header(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .background(ColorPalette.OffWhite)
             .padding(start = 16.dp, top = 24.dp, end = 16.dp, bottom = 8.dp)
     ) {
         Text(
@@ -110,6 +132,42 @@ fun MethodItem(
             Text(
                 text = method.name,
                 style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
+            )
+        }
+    }
+}
+
+@Composable
+fun CategoryItem(
+    category: Category
+) {
+    Column(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+    ) {
+        Divider(color = ColorPalette.Purple40, thickness = 1.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = category.name,
+                style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
+            )
+            Text(
+                text = category.name,
+                style = MaterialTheme.typography.subtitle2.copy(
+                    fontWeight = FontWeight(700),
+                    color = ColorPalette.White
+                ),
+                modifier = Modifier
+                    .widthIn(56.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(Color(category.categoryColor))
+                    .padding(start = 8.dp, top = 4.dp, end = 8.dp, bottom = 4.dp),
+                textAlign = TextAlign.Center
             )
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -1,9 +1,39 @@
 package com.seom.accountbook.ui.screen.setting
 
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.seom.accountbook.ui.theme.ColorPalette
 
 @Composable
 fun SettingScreen() {
-    Text(text = "setting")
+    Scaffold(
+        topBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = "설정",
+                    style = MaterialTheme.typography.body1.copy(color = ColorPalette.Purple)
+                )
+            }
+        }
+    ) {
+        Column {
+            Divider(
+                color = ColorPalette.Purple,
+                thickness = 1.dp
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -1,5 +1,6 @@
 package com.seom.accountbook.ui.screen.setting.category
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -68,7 +69,7 @@ fun CategoryAddScreen(
     val colorList = if (categoryType == HistoryType.INCOME) incomeColor else outcomeColor
 
     var name by remember { mutableStateOf("") }
-    val selectedIndex by remember { mutableStateOf(0) }
+    var selectedIndex by remember { mutableStateOf(0) }
 
     Scaffold(topBar = {
         OneButtonAppBar(title = "$title 카테고리 $modeTitle") {
@@ -104,7 +105,9 @@ fun CategoryAddScreen(
                     Divider(color = ColorPalette.Purple40, thickness = 1.dp)
                 }
 
-                ColorSelector(colors = colorList, perLine = 10, selectedIndex = selectedIndex)
+                ColorSelector(colors = colorList, perLine = 10, selectedIndex = selectedIndex) {
+                    selectedIndex = it
+                }
                 Spacer(modifier = Modifier.height(5.dp))
                 Divider(color = ColorPalette.LightPurple, thickness = 1.dp)
             }
@@ -142,7 +145,8 @@ fun ColorSelector(
     colors: List<Color>,
     perLine: Int,
     selectedIndex: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onSelectItem: (Int) -> Unit
 ) {
     var rowNum = colors.size / perLine
     if (colors.size % perLine != 0)
@@ -155,11 +159,13 @@ fun ColorSelector(
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
                 (0 until min(perLine, colors.size)).forEachIndexed { _, column ->
+                    val paddingAnimation by animateDpAsState(targetValue = if (row * perLine + column == selectedIndex) 0.dp else 4.dp)
                     Spacer(
                         modifier = Modifier
                             .size(24.dp)
-                            .padding(if (row * perLine + column == selectedIndex) 0.dp else 4.dp)
+                            .padding(paddingAnimation)
                             .background(colors[row * perLine + column])
+                            .clickable { onSelectItem(row * perLine + column) }
                     )
                 }
             }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -2,13 +2,21 @@ package com.seom.accountbook.ui.screen.setting.category
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.material.Scaffold
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
 import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.components.OneButtonAppBar
+import com.seom.accountbook.ui.screen.setting.method.Input
+import com.seom.accountbook.ui.screen.setting.method.InputField
+import com.seom.accountbook.ui.theme.ColorPalette
 
 @Composable
 fun CategoryAddScreen(
@@ -19,6 +27,8 @@ fun CategoryAddScreen(
     val title = if (categoryType == HistoryType.INCOME) "수입" else "지출"
     val modeTitle = if (categoryId.isNullOrBlank()) "추가하기" else "수정하기"
 
+    var name by remember { mutableStateOf("") }
+
     Scaffold(topBar = {
         OneButtonAppBar(title = "$title 카테고리 $modeTitle") {
             Image(
@@ -27,6 +37,14 @@ fun CategoryAddScreen(
                 modifier = Modifier.clickable { onBackButtonPressed() })
         }
     }) {
-
+        Box {
+            Divider(
+                color = ColorPalette.Purple,
+                thickness = 1.dp
+            )
+            InputField(title = "이름") {
+                Input(content = name, onValueChange = { name = it })
+            }
+        }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -1,11 +1,12 @@
 package com.seom.accountbook.ui.screen.setting.category
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -37,7 +38,9 @@ fun CategoryAddScreen(
                 modifier = Modifier.clickable { onBackButtonPressed() })
         }
     }) {
-        Box {
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ) {
             Divider(
                 color = ColorPalette.Purple,
                 thickness = 1.dp
@@ -45,6 +48,31 @@ fun CategoryAddScreen(
             InputField(title = "이름") {
                 Input(content = name, onValueChange = { name = it })
             }
+
+            Button(
+                onClick = { onBackButtonPressed() },
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 40.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = ColorPalette.Yellow,
+                    disabledBackgroundColor = ColorPalette.Yellow50
+                ),
+                enabled = name.isNullOrBlank().not()
+            ) {
+                Text(
+                    text = "등록하기",
+                    style = MaterialTheme.typography.caption.copy(
+                        fontWeight = FontWeight(700),
+                        color = ColorPalette.White
+                    ),
+                    modifier = Modifier
+                        .padding(top = 8.dp, bottom = 8.dp)
+                        .background(Color.Transparent),
+                )
+            }
         }
+
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -12,12 +12,50 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import com.seom.accountbook.R
 import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.components.OneButtonAppBar
 import com.seom.accountbook.ui.screen.setting.method.Input
 import com.seom.accountbook.ui.screen.setting.method.InputField
 import com.seom.accountbook.ui.theme.ColorPalette
+import kotlin.math.min
+
+val outcomeColor = listOf(
+    Color(0xFF4A6CC3),
+    Color(0xFF2E86C7),
+    Color(0xFF4CA1DE),
+    Color(0xFF48C2E9),
+    Color(0xFF6ED5EB),
+    Color(0xFF9FE7C8),
+    Color(0xFF94D3CC),
+    Color(0xFF4CB8B8),
+    Color(0xFF40B98D),
+    Color(0xFF2FA488),
+    Color(0xFF625EBA),
+    Color(0xFF817DCE),
+    Color(0xFF9B7DCE),
+    Color(0xFFB391EB),
+    Color(0xFFD092E2),
+    Color(0xFFF1B4EF),
+    Color(0xFFF4AEE1),
+    Color(0xFFF396B8),
+    Color(0xFFDC5D7B),
+    Color(0xFFCB588F)
+)
+
+val incomeColor = listOf(
+    Color(0xFF9BD182),
+    Color(0xFFA3CB7A),
+    Color(0xFFB5CC7A),
+    Color(0xFFCCD67A),
+    Color(0xFFEAE07C),
+    Color(0xFFEDCF65),
+    Color(0xFFEBC374),
+    Color(0xFFE1AD60),
+    Color(0xFFE29C4D),
+    Color(0xFFE39145)
+)
 
 @Composable
 fun CategoryAddScreen(
@@ -27,8 +65,10 @@ fun CategoryAddScreen(
 ) {
     val title = if (categoryType == HistoryType.INCOME) "수입" else "지출"
     val modeTitle = if (categoryId.isNullOrBlank()) "추가하기" else "수정하기"
+    val colorList = if (categoryType == HistoryType.INCOME) incomeColor else outcomeColor
 
     var name by remember { mutableStateOf("") }
+    val selectedIndex by remember { mutableStateOf(0) }
 
     Scaffold(topBar = {
         OneButtonAppBar(title = "$title 카테고리 $modeTitle") {
@@ -45,8 +85,28 @@ fun CategoryAddScreen(
                 color = ColorPalette.Purple,
                 thickness = 1.dp
             )
-            InputField(title = "이름") {
-                Input(content = name, onValueChange = { name = it })
+            Column {
+                InputField(title = "이름") {
+                    Input(content = name, onValueChange = { name = it })
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                Column(
+                    modifier = Modifier.padding(
+                        start = 16.dp,
+                        end = 16.dp
+                    )
+                ) {
+                    Text(
+                        text = "색상",
+                        style = MaterialTheme.typography.body2.copy(color = ColorPalette.LightPurple),
+                        modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)
+                    )
+                    Divider(color = ColorPalette.Purple40, thickness = 1.dp)
+                }
+
+                ColorSelector(colors = colorList, perLine = 10, selectedIndex = selectedIndex)
+                Spacer(modifier = Modifier.height(5.dp))
+                Divider(color = ColorPalette.LightPurple, thickness = 1.dp)
             }
 
             Button(
@@ -74,5 +134,35 @@ fun CategoryAddScreen(
             }
         }
 
+    }
+}
+
+@Composable
+fun ColorSelector(
+    colors: List<Color>,
+    perLine: Int,
+    selectedIndex: Int,
+    modifier: Modifier = Modifier
+) {
+    var rowNum = colors.size / perLine
+    if (colors.size % perLine != 0)
+        rowNum++
+
+    Column(modifier.padding(16.dp)) {
+        (0 until rowNum).forEachIndexed { _, row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                (0 until min(perLine, colors.size)).forEachIndexed { _, column ->
+                    Spacer(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .padding(if (row * perLine + column == selectedIndex) 0.dp else 4.dp)
+                            .background(colors[row * perLine + column])
+                    )
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -1,0 +1,32 @@
+package com.seom.accountbook.ui.screen.setting.category
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.seom.accountbook.R
+import com.seom.accountbook.model.history.HistoryType
+import com.seom.accountbook.ui.components.OneButtonAppBar
+
+@Composable
+fun CategoryAddScreen(
+    categoryId: String? = null,
+    categoryType: HistoryType,
+    onBackButtonPressed: () -> Unit
+) {
+    val title = if (categoryType == HistoryType.INCOME) "수입" else "지출"
+    val modeTitle = if (categoryId.isNullOrBlank()) "추가하기" else "수정하기"
+
+    Scaffold(topBar = {
+        OneButtonAppBar(title = "$title 카테고리 $modeTitle") {
+            Image(
+                painter = painterResource(id = R.drawable.ic_back),
+                contentDescription = null,
+                modifier = Modifier.clickable { onBackButtonPressed() })
+        }
+    }) {
+
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
@@ -1,0 +1,28 @@
+package com.seom.accountbook.ui.screen.setting.method
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.seom.accountbook.R
+import com.seom.accountbook.ui.components.OneButtonAppBar
+
+@Composable
+fun MethodAddScreen(
+    methodId: String? = null,
+    onBackButtonPressed: () -> Unit
+) {
+    val modeTitle = if (methodId.isNullOrBlank()) "추가하기" else "수정하기"
+    Scaffold(topBar = {
+        OneButtonAppBar(title = "결제 수단 $modeTitle") {
+            Image(
+                painter = painterResource(id = R.drawable.ic_back),
+                contentDescription = null,
+                modifier = Modifier.clickable { onBackButtonPressed() })
+        }
+    }) {
+
+    }
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
@@ -1,11 +1,13 @@
 package com.seom.accountbook.ui.screen.setting.method
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -31,13 +33,36 @@ fun MethodAddScreen(
                 modifier = Modifier.clickable { onBackButtonPressed() })
         }
     }) {
-        Box {
+        Box(modifier = Modifier.fillMaxSize()) {
             Divider(
                 color = ColorPalette.Purple,
                 thickness = 1.dp
             )
             InputField(title = "이름") {
                 Input(content = name, onValueChange = { name = it })
+            }
+            Button(
+                onClick = { onBackButtonPressed() },
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 40.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = ColorPalette.Yellow,
+                    disabledBackgroundColor = ColorPalette.Yellow50
+                ),
+                enabled = name.isNullOrBlank().not()
+            ) {
+                Text(
+                    text = "등록하기",
+                    style = MaterialTheme.typography.caption.copy(
+                        fontWeight = FontWeight(700),
+                        color = ColorPalette.White
+                    ),
+                    modifier = Modifier
+                        .padding(top = 8.dp, bottom = 8.dp)
+                        .background(Color.Transparent),
+                )
             }
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodAddScreen.kt
@@ -2,12 +2,18 @@ package com.seom.accountbook.ui.screen.setting.method
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.material.Scaffold
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
 import com.seom.accountbook.ui.components.OneButtonAppBar
+import com.seom.accountbook.ui.theme.ColorPalette
 
 @Composable
 fun MethodAddScreen(
@@ -15,6 +21,8 @@ fun MethodAddScreen(
     onBackButtonPressed: () -> Unit
 ) {
     val modeTitle = if (methodId.isNullOrBlank()) "추가하기" else "수정하기"
+    var name by remember { mutableStateOf("") }
+
     Scaffold(topBar = {
         OneButtonAppBar(title = "결제 수단 $modeTitle") {
             Image(
@@ -23,6 +31,71 @@ fun MethodAddScreen(
                 modifier = Modifier.clickable { onBackButtonPressed() })
         }
     }) {
+        Box {
+            Divider(
+                color = ColorPalette.Purple,
+                thickness = 1.dp
+            )
+            InputField(title = "이름") {
+                Input(content = name, onValueChange = { name = it })
+            }
+        }
+    }
+}
 
+@Composable
+fun InputField(
+    title: String,
+    input: @Composable () -> Unit
+) {
+    Column(modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 16.dp)) {
+        Row(
+            modifier = Modifier
+                .padding(
+                    top = 8.dp,
+                    bottom = 8.dp
+                )
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.caption,
+                fontWeight = FontWeight(500),
+                color = ColorPalette.Purple,
+                modifier = Modifier.weight(2f)
+            )
+            Surface(
+                modifier = Modifier
+                    .weight(8f)
+                    .padding(start = 8.dp),
+                color = Color.Transparent
+            ) {
+                input()
+            }
+        }
+        Divider(
+            color = ColorPalette.Purple40,
+            thickness = 1.dp
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+@Composable
+fun Input(
+    content: String,
+    onValueChange: (String) -> Unit
+) {
+    Box() {
+        BasicTextField(
+            value = content,
+            onValueChange = { onValueChange(it) },
+            textStyle = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple),
+        )
+        if (content.isBlank()) {
+            Text(
+                text = "입력하세요.",
+                style = MaterialTheme.typography.caption.copy(color = ColorPalette.LightPurple)
+            )
+        }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -8,12 +8,15 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.seom.accountbook.*
+import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.screen.calendar.CalendarScreen
 import com.seom.accountbook.ui.screen.detail.DetailScreen
 import com.seom.accountbook.ui.screen.graph.GraphScreen
 import com.seom.accountbook.ui.screen.history.HistoryScreen
 import com.seom.accountbook.ui.screen.post.PostScreen
 import com.seom.accountbook.ui.screen.setting.SettingScreen
+import com.seom.accountbook.ui.screen.setting.category.CategoryAddScreen
+import com.seom.accountbook.ui.screen.setting.method.MethodAddScreen
 
 @Composable
 fun AccountNavigationHost(
@@ -47,7 +50,9 @@ fun AccountNavigationHost(
             )
         }
         composable(route = Setting.route) {
-            SettingScreen()
+            SettingScreen { route, args ->
+                navController.navigateSingleTop(route, args)
+            }
         }
         composable(
             route = Post.routeWithArgs,
@@ -74,6 +79,51 @@ fun AccountNavigationHost(
                 categoryId = categoryId,
                 onBackButtonPressed = { navController.popBackStack() }
             )
+        }
+        // 결제 수단 새로 추가
+        composable(
+            route = Method.route
+        ) {
+            MethodAddScreen {
+                navController.popBackStack()
+            }
+        }
+        // 결제 수단 변경
+        composable(
+            route = Method.routeWithArgs,
+            arguments = Method.arguments
+        ) { navBackStackEntry ->
+            val methodId = navBackStackEntry.arguments?.getString(Method.methodIdArgs)
+            MethodAddScreen(methodId) {
+                navController.popBackStack()
+            }
+        }
+        // 카테고리 새로 추가
+        composable(
+            route = Category.routeWithArgs,
+            arguments = Category.arguments
+        ) { navBackStackEntry ->
+            val categoryType = navBackStackEntry.arguments?.getString(Category.categoryTypeArgs)
+            CategoryAddScreen(
+                null,
+                HistoryType.getHistoryType(categoryType?.toInt() ?: 0),
+            ) {
+                navController.popBackStack()
+            }
+        }
+        // 카테고리 변경
+        composable(
+            route = Category.routeWithAllArgs,
+            arguments = Category.allArguments
+        ) { navBackStackEntry ->
+            val categoryId = navBackStackEntry.arguments?.getString(Category.categoryIdArgs)
+            val categoryType = navBackStackEntry.arguments?.getString(Category.categoryTypeArgs)
+            CategoryAddScreen(
+                categoryId,
+                HistoryType.getHistoryType(categoryType?.toInt() ?: 0),
+            ) {
+                navController.popBackStack()
+            }
         }
     }
 }


### PR DESCRIPTION
### 📌 Summary
결제 수단과 지출/수입 카테고리 관리 화면 기본 UI 구현하기

### 🍿 Main Changes
- [x] 결제수단 리스트 그리기
- [x] 카테고리 리스트 그리기
- [x] 결제 수단 리스트에 데이터 바인딩하기
- [x] 카테고리 리스트에 수입/지출 카테고리 데이터 바인딩하기
- [x] 결제 수단 추가 버튼 누르면 결제 수단 추가 화면으로 이동하기
- [x] 카테고리 추가 버튼 누르면 카테고리 추가 화면으로 이동하기

##### 추가 화면
- [x] 상단 앱바 구성하기
- [x] 상단 앱바 버튼 클릭 시, 이전 화면으로 이동하기
- [x] 결제 수단 이름 입력란 만들기
- [x] 결제 수단 이름 입력 전까지 버튼 비활성화 하기
- [x] 등록하기 버튼 클릭 시, 이전 화면으로 이동하기
- [x] 색상 리스트 만들기
- [x] 선택된 색상은 크게 만들어주기(애니메이션 사용)

### 🔥 UseCase
<img width="781" alt="스크린샷 2022-07-30 오후 11 07 46" src="https://user-images.githubusercontent.com/22411296/181918048-6ebad576-48c4-4355-84ba-55dbe7d1741f.png">

### 🛠 Related Issue
Closes #20