### PR TITLE
설정 화면 DataLayer단 구성하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
@@ -3,11 +3,13 @@ package com.seom.accountbook.data.entity.category
 import android.provider.BaseColumns
 
 data class CategoryEntity(
+    val id: Long,
     val name: String, // 카테고리 이름
     val color: Long, // 카테고리 색상
     val type: Int // 카테고리 타입(0: 수입, 1: 지출)
-) : BaseColumns {
+) {
     companion object {
+        const val COLUMN_NAME_ID = "ID"
         const val COLUMN_NAME_NAME = "NAME"
         const val COLUMN_NAME_COLOR = "COLOR"
         const val COLUMN_NAME_TYPE = "TYPE"

--- a/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
@@ -3,7 +3,7 @@ package com.seom.accountbook.data.entity.category
 import android.provider.BaseColumns
 
 data class CategoryEntity(
-    val id: Long?,
+    val id: Long? = null,
     val name: String, // 카테고리 이름
     val color: Long, // 카테고리 색상
     val type: Int // 카테고리 타입(0: 수입, 1: 지출)

--- a/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
@@ -3,7 +3,7 @@ package com.seom.accountbook.data.entity.category
 import android.provider.BaseColumns
 
 data class CategoryEntity(
-    val id: Long,
+    val id: Long?,
     val name: String, // 카테고리 이름
     val color: Long, // 카테고리 색상
     val type: Int // 카테고리 타입(0: 수입, 1: 지출)

--- a/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/category/CategoryEntity.kt
@@ -1,13 +1,14 @@
 package com.seom.accountbook.data.entity.category
 
 import android.provider.BaseColumns
+import com.seom.accountbook.model.BaseModel
 
 data class CategoryEntity(
-    val id: Long? = null,
-    val name: String, // 카테고리 이름
+    override val id: Long? = null,
+    override val name: String, // 카테고리 이름
     val color: Long, // 카테고리 색상
     val type: Int // 카테고리 타입(0: 수입, 1: 지출)
-) {
+): BaseModel {
     companion object {
         const val COLUMN_NAME_ID = "ID"
         const val COLUMN_NAME_NAME = "NAME"

--- a/app/src/main/java/com/seom/accountbook/data/entity/method/MethodEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/method/MethodEntity.kt
@@ -3,9 +3,11 @@ package com.seom.accountbook.data.entity.method
 import android.provider.BaseColumns
 
 data class MethodEntity(
+    val id: Long,
     val name: String // 결제 수단 이름
-): BaseColumns {
+) {
     companion object {
+        const val COLUMN_NAME_ID = "ID"
         const val COLUMN_NAME_NAME = "NAME"
     }
 }

--- a/app/src/main/java/com/seom/accountbook/data/entity/method/MethodEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/method/MethodEntity.kt
@@ -3,7 +3,7 @@ package com.seom.accountbook.data.entity.method
 import android.provider.BaseColumns
 
 data class MethodEntity(
-    val id: Long,
+    val id: Long? = null,
     val name: String // 결제 수단 이름
 ) {
     companion object {

--- a/app/src/main/java/com/seom/accountbook/data/entity/method/MethodEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/method/MethodEntity.kt
@@ -1,11 +1,12 @@
 package com.seom.accountbook.data.entity.method
 
 import android.provider.BaseColumns
+import com.seom.accountbook.model.BaseModel
 
 data class MethodEntity(
-    val id: Long? = null,
-    val name: String // 결제 수단 이름
-) {
+    override val id: Long? = null,
+    override val name: String // 결제 수단 이름
+): BaseModel {
     companion object {
         const val COLUMN_NAME_ID = "ID"
         const val COLUMN_NAME_NAME = "NAME"

--- a/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
@@ -99,7 +99,7 @@ class AccountDao(
             "1"
         )
 
-        return cursor?.let {
+        return cursor?.use {
             cursor.moveToFirst()
             AccountEntity(
                 id = cursor.getLong(0),

--- a/app/src/main/java/com/seom/accountbook/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/AppDatabase.kt
@@ -1,8 +1,13 @@
 package com.seom.accountbook.data.local
 
+import android.content.ContentValues
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
+import com.seom.accountbook.data.entity.category.CategoryEntity
+import com.seom.accountbook.data.entity.method.MethodEntity
+import com.seom.accountbook.di.provideAccountDao
+import com.seom.accountbook.di.provideCategoryDao
 
 class AppDatabase(context: Context) :
     SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
@@ -17,6 +22,22 @@ class AppDatabase(context: Context) :
         db.execSQL(MethodDao.CREATE_TABLE)
         db.execSQL(CategoryDao.CREATE_TABLE)
         db.execSQL(AccountDao.CREATE_TABLE)
+
+        // 기본 데이터 추가
+        CategoryDao.INIT_DATA.forEach {
+            val values = ContentValues().apply {
+                put(CategoryEntity.COLUMN_NAME_NAME, it.name)
+                put(CategoryEntity.COLUMN_NAME_COLOR, it.color)
+                put(CategoryEntity.COLUMN_NAME_TYPE, it.type)
+            }
+            db.insertOrThrow(CategoryDao.TABLE_NAME, null, values)
+        }
+        MethodDao.INIT_DATA.forEach {
+            val values = ContentValues().apply {
+                put(MethodEntity.COLUMN_NAME_NAME, it.name)
+            }
+            db.insertOrThrow(MethodDao.TABLE_NAME, null, values)
+        }
     }
 
     override fun onUpgrade(p0: SQLiteDatabase?, p1: Int, p2: Int) {

--- a/app/src/main/java/com/seom/accountbook/data/local/CategoryDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/CategoryDao.kt
@@ -1,16 +1,128 @@
 package com.seom.accountbook.data.local
 
+import android.content.ContentValues
 import android.provider.BaseColumns
+import com.seom.accountbook.data.entity.account.AccountEntity
 import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.entity.method.MethodEntity
+import com.seom.accountbook.di.provideAppDatabase
 
-object CategoryDao {
-    const val TABLE_NAME = "CATEGORY"
+class CategoryDao(
+    val appDatabase: AppDatabase = provideAppDatabase()
+) {
+    companion object {
+        const val TABLE_NAME = "CATEGORY"
 
-    const val CREATE_TABLE = "" +
-            "CREATE TABLE $TABLE_NAME (" +
-            "${BaseColumns._ID} INTEGER PRIMARY KEY AUTOINCREMENT," +
-            "${CategoryEntity.COLUMN_NAME_NAME} TEXT NOT NULL," +
-            "${CategoryEntity.COLUMN_NAME_COLOR} INTEGER NOT NULL," +
-            "${CategoryEntity.COLUMN_NAME_TYPE} INT NOT NULL)"
+        const val CREATE_TABLE = "" +
+                "CREATE TABLE $TABLE_NAME (" +
+                "${CategoryEntity.COLUMN_NAME_ID} INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "${CategoryEntity.COLUMN_NAME_NAME} TEXT NOT NULL," +
+                "${CategoryEntity.COLUMN_NAME_COLOR} INTEGER NOT NULL," +
+                "${CategoryEntity.COLUMN_NAME_TYPE} INT NOT NULL)"
+    }
+
+    fun addCategory(category: CategoryEntity): Long? {
+        val db = appDatabase.writable
+        val values = ContentValues().apply {
+            put(CategoryEntity.COLUMN_NAME_NAME, category.name)
+            put(CategoryEntity.COLUMN_NAME_COLOR, category.color)
+            put(CategoryEntity.COLUMN_NAME_TYPE, category.type)
+        }
+
+        return db?.insert(TABLE_NAME, null, values)
+    }
+
+    fun updateCategory(category: CategoryEntity): Int {
+        val db = appDatabase.writable
+        val values = ContentValues().apply {
+            put(CategoryEntity.COLUMN_NAME_NAME, category.name)
+            put(CategoryEntity.COLUMN_NAME_COLOR, category.color)
+        }
+
+        val selection = "${CategoryEntity.COLUMN_NAME_ID} = ?"
+        val selectionArgs = arrayOf(category.id.toString())
+
+        val result = db.update(
+            TABLE_NAME,
+            values,
+            selection,
+            selectionArgs
+        )
+
+        return result
+    }
+
+    fun getAllCategory(): List<CategoryEntity> {
+        val db = appDatabase.readable
+        val projection = arrayOf(
+            CategoryEntity.COLUMN_NAME_ID,
+            CategoryEntity.COLUMN_NAME_NAME,
+            CategoryEntity.COLUMN_NAME_COLOR,
+            CategoryEntity.COLUMN_NAME_TYPE
+        )
+
+        val cursor = db.query(
+            TABLE_NAME,
+            projection,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+
+        val categories = mutableListOf<CategoryEntity>()
+
+        if (cursor.moveToFirst()) {
+            do {
+                categories.add(
+                    CategoryEntity(
+                        id = cursor.getLong(0),
+                        name = cursor.getString(1),
+                        color = cursor.getLong(2),
+                        type = cursor.getInt(3)
+                    )
+                )
+            } while (cursor.moveToNext())
+        }
+        cursor.close()
+        return categories.toList()
+    }
+
+    fun getCategory(id: Long): CategoryEntity? {
+        val db = appDatabase.readable
+
+        val projection = arrayOf(
+            CategoryEntity.COLUMN_NAME_ID,
+            CategoryEntity.COLUMN_NAME_NAME,
+            CategoryEntity.COLUMN_NAME_COLOR,
+            CategoryEntity.COLUMN_NAME_TYPE
+        )
+        val selection = "${CategoryEntity.COLUMN_NAME_ID} = ?"
+        val selectoinArgs = arrayOf(id.toString())
+
+        val cursor = db.query(
+            TABLE_NAME,
+            projection,
+            selection,
+            selectoinArgs,
+            null,
+            null,
+            null,
+            "1"
+        )
+
+        return cursor?.use {
+            cursor.moveToFirst()
+            CategoryEntity(
+                id = cursor.getLong(0),
+                name = cursor.getString(1),
+                color = cursor.getLong(2),
+                type = cursor.getInt(3)
+            )
+        } ?: kotlin.run {
+            null
+        }
+    }
 }

--- a/app/src/main/java/com/seom/accountbook/data/local/CategoryDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/CategoryDao.kt
@@ -6,6 +6,7 @@ import com.seom.accountbook.data.entity.account.AccountEntity
 import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.entity.method.MethodEntity
 import com.seom.accountbook.di.provideAppDatabase
+import com.seom.accountbook.model.history.HistoryType
 
 class CategoryDao(
     val appDatabase: AppDatabase = provideAppDatabase()
@@ -19,17 +20,34 @@ class CategoryDao(
                 "${CategoryEntity.COLUMN_NAME_NAME} TEXT NOT NULL," +
                 "${CategoryEntity.COLUMN_NAME_COLOR} INTEGER NOT NULL," +
                 "${CategoryEntity.COLUMN_NAME_TYPE} INT NOT NULL)"
+
+        val INIT_DATA = listOf(
+            CategoryEntity(name = "교통", color = 0xFF94D3CC, type = HistoryType.OUTCOME.type),
+            CategoryEntity(name = "문화/여가", color = 0xFFD092E2, type = HistoryType.OUTCOME.type),
+            CategoryEntity(name = "미분류", color = 0xFF817DCE, type = HistoryType.OUTCOME.type),
+            CategoryEntity(name = "생활", color = 0xFF4A6CC3, type = HistoryType.OUTCOME.type),
+            CategoryEntity(name = "쇼핑/뷰티", color = 0xFF4CB8B8, type = HistoryType.OUTCOME.type),
+            CategoryEntity(name = "식비", color = 0xFF4CA1DE, type = HistoryType.OUTCOME.type),
+            CategoryEntity(name = "의료/건강", color = 0xFF6ED5EB, type = HistoryType.OUTCOME.type),
+            CategoryEntity(name = "월급", color = 0xFF9BD182, type = HistoryType.INCOME.type),
+            CategoryEntity(name = "용돈", color = 0xFFEDCF65, type = HistoryType.INCOME.type),
+            CategoryEntity(name = "기타", color = 0xFFE29C4D, type = HistoryType.INCOME.type)
+        )
     }
 
     fun addCategory(category: CategoryEntity): Long? {
         val db = appDatabase.writable
+        if (checkCategoryName(category.name)) {
+            println("check category name")
+            return null
+        }
         val values = ContentValues().apply {
             put(CategoryEntity.COLUMN_NAME_NAME, category.name)
             put(CategoryEntity.COLUMN_NAME_COLOR, category.color)
             put(CategoryEntity.COLUMN_NAME_TYPE, category.type)
         }
 
-        return db?.insert(TABLE_NAME, null, values)
+        return db?.insertOrThrow(TABLE_NAME, null, values)
     }
 
     fun updateCategory(category: CategoryEntity): Int {
@@ -88,6 +106,33 @@ class CategoryDao(
         }
         cursor.close()
         return categories.toList()
+    }
+
+    private fun checkCategoryName(name: String): Boolean {
+        val db = appDatabase.readable
+
+        val projection = arrayOf(
+            CategoryEntity.COLUMN_NAME_ID
+        )
+        val selection = "${CategoryEntity.COLUMN_NAME_NAME} = ?"
+        val selectionArgs = arrayOf(name)
+
+        val cursor = db.query(
+            TABLE_NAME,
+            projection,
+            selection,
+            selectionArgs,
+            null,
+            null,
+            null,
+            "1"
+        )
+
+        return cursor?.use {
+            cursor.moveToFirst()
+        } ?: kotlin.run {
+            false
+        }
     }
 
     fun getCategory(id: Long): CategoryEntity? {

--- a/app/src/main/java/com/seom/accountbook/data/local/MethodDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/MethodDao.kt
@@ -16,6 +16,11 @@ class MethodDao(
                 "CREATE TABLE $TABLE_NAME (" +
                 "${MethodEntity.COLUMN_NAME_ID} INTEGER PRIMARY KEY AUTOINCREMENT," +
                 "${MethodEntity.COLUMN_NAME_NAME} TEXT NOT NULL)"
+
+        val INIT_DATA = listOf(
+            MethodEntity(name = "현대카드"),
+            MethodEntity(name = "카카오뱅크 체크카드")
+        )
     }
 
     fun addMethod(method: MethodEntity): Long? {

--- a/app/src/main/java/com/seom/accountbook/data/local/MethodDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/MethodDao.kt
@@ -1,13 +1,112 @@
 package com.seom.accountbook.data.local
 
+import android.content.ContentValues
 import android.provider.BaseColumns
+import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.entity.method.MethodEntity
+import com.seom.accountbook.di.provideAppDatabase
 
-object MethodDao {
-    const val TABLE_NAME = "METHOD"
+class MethodDao(
+    private val appDatabase: AppDatabase = provideAppDatabase()
+) {
+    companion object {
+        const val TABLE_NAME = "METHOD"
 
-    const val CREATE_TABLE = "" +
-            "CREATE TABLE $TABLE_NAME (" +
-            "${BaseColumns._ID} INTEGER PRIMARY KEY AUTOINCREMENT," +
-            "${MethodEntity.COLUMN_NAME_NAME} TEXT NOT NULL)"
+        const val CREATE_TABLE = "" +
+                "CREATE TABLE $TABLE_NAME (" +
+                "${MethodEntity.COLUMN_NAME_ID} INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "${MethodEntity.COLUMN_NAME_NAME} TEXT NOT NULL)"
+    }
+
+    fun addMethod(method: MethodEntity): Long? {
+        val db = appDatabase.writable
+        val values = ContentValues().apply {
+            put(MethodEntity.COLUMN_NAME_NAME, method.name)
+        }
+
+        return db?.insert(TABLE_NAME, null, values)
+    }
+
+    fun getAllMethods(): List<MethodEntity> {
+        val db = appDatabase.readable
+        val projectoin = arrayOf(
+            MethodEntity.COLUMN_NAME_ID,
+            MethodEntity.COLUMN_NAME_NAME
+        )
+
+        val cursor = db.query(
+            TABLE_NAME,
+            projectoin,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+
+        val methods = mutableListOf<MethodEntity>()
+        if (cursor.moveToFirst()) {
+            do {
+                methods.add(
+                    MethodEntity(
+                        id = cursor.getLong(0),
+                        name = cursor.getString(1)
+                    )
+                )
+            } while (cursor.moveToNext())
+        }
+        cursor.close()
+        return methods.toList()
+    }
+
+    fun getMethods(id: Long): MethodEntity? {
+        val db = appDatabase.readable
+        val projection = arrayOf(
+            MethodEntity.COLUMN_NAME_ID,
+            MethodEntity.COLUMN_NAME_NAME
+        )
+
+        val selection = "${MethodEntity.COLUMN_NAME_ID} = ?"
+        val selectoinArgs = arrayOf(id.toString())
+
+        val cursor = db.query(
+            TABLE_NAME,
+            projection,
+            selection,
+            selectoinArgs,
+            null,
+            null,
+            null,
+            "1"
+        )
+        return cursor?.use {
+            cursor.moveToFirst()
+            MethodEntity(
+                id = cursor.getLong(0),
+                name = cursor.getString(1)
+            )
+        } ?: kotlin.run {
+            null
+        }
+    }
+
+    fun updateMethod(method: MethodEntity): Int {
+        val db = appDatabase.writable
+        val values = ContentValues().apply {
+            put(MethodEntity.COLUMN_NAME_NAME, method.name)
+        }
+
+        val selection = "${MethodEntity.COLUMN_NAME_ID} = ?"
+        val selctionArgs = arrayOf(method.id.toString())
+
+        val result = db.update(
+            TABLE_NAME,
+            values,
+            selection,
+            selctionArgs
+        )
+
+        return result
+    }
 }

--- a/app/src/main/java/com/seom/accountbook/data/repository/CategoryRepository.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/CategoryRepository.kt
@@ -1,0 +1,18 @@
+package com.seom.accountbook.data.repository
+
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.category.CategoryEntity
+
+interface CategoryRepository {
+    // 수입/지출 카테고리 추가
+    suspend fun addCategory(category: CategoryEntity): Result<Long>
+
+    // 수입/지출 카테고리 업데이트
+    suspend fun updateCategory(category: CategoryEntity): Result<Int>
+
+    // 특정 수입/지출 카테고리 요청
+    suspend fun getCategory(id: Long): Result<CategoryEntity>
+
+    // 모든 수입/지출 카테고리 요청
+    suspend fun getAllCategories(): Result<List<CategoryEntity>>
+}

--- a/app/src/main/java/com/seom/accountbook/data/repository/MethodRepository.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/MethodRepository.kt
@@ -1,0 +1,18 @@
+package com.seom.accountbook.data.repository
+
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.method.MethodEntity
+
+interface MethodRepository {
+    // 수입/지출 카테고리 추가
+    suspend fun addMethod(method: MethodEntity): Result<Long>
+
+    // 수입/지출 카테고리 업데이트
+    suspend fun updateMethod(method: MethodEntity): Result<Int>
+
+    // 특정 수입/지출 카테고리 요청
+    suspend fun getMethod(id: Long): Result<MethodEntity>
+
+    // 모든 수입/지출 카테고리 요청
+    suspend fun getAllMethods(): Result<List<MethodEntity>>
+}

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/CategoryRepositoryImpl.kt
@@ -1,0 +1,63 @@
+package com.seom.accountbook.data.repository.impl
+
+import com.seom.accountbook.data.entity.category.CategoryEntity
+import com.seom.accountbook.data.local.CategoryDao
+import com.seom.accountbook.data.repository.CategoryRepository
+import com.seom.accountbook.di.provideCategoryDao
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import com.seom.accountbook.data.entity.Result
+
+class CategoryRepositoryImpl(
+    private val categoryDao: CategoryDao = provideCategoryDao(),
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : CategoryRepository {
+    override suspend fun addCategory(category: CategoryEntity): Result<Long> =
+        withContext(ioDispatcher) {
+            try {
+                val categoryId = categoryDao.addCategory(category)
+
+                if (categoryId != null) Result.Success(categoryId)
+                else throw Exception("")
+            } catch (exception: Exception) {
+                Result.Error(exception.toString())
+            }
+        }
+
+    override suspend fun updateCategory(category: CategoryEntity): Result<Int> =
+        withContext(ioDispatcher) {
+            try {
+                val result = categoryDao.updateCategory(category)
+
+                if (result > 0) Result.Success(result)
+                else throw Exception("")
+            } catch (exception: Exception) {
+                Result.Error(exception.toString())
+            }
+        }
+
+    override suspend fun getCategory(id: Long): Result<CategoryEntity> =
+        withContext(ioDispatcher) {
+            try {
+                val category = categoryDao.getCategory(id)
+
+                if (category != null) Result.Success(category)
+                else throw Exception("")
+            } catch (exception: Exception) {
+                Result.Error(exception.toString())
+            }
+        }
+
+    override suspend fun getAllCategories(): Result<List<CategoryEntity>> =
+        withContext(ioDispatcher) {
+            try {
+                val categories = categoryDao.getAllCategory()
+
+                if (categories.size > 0) Result.Success(categories)
+                else throw Exception()
+            } catch (exception: Exception) {
+                Result.Error(exception.toString())
+            }
+        }
+}

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/CategoryRepositoryImpl.kt
@@ -53,9 +53,7 @@ class CategoryRepositoryImpl(
         withContext(ioDispatcher) {
             try {
                 val categories = categoryDao.getAllCategory()
-
-                if (categories.isNotEmpty()) Result.Success(categories)
-                else throw Exception()
+                Result.Success(categories)
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
@@ -1,34 +1,35 @@
 package com.seom.accountbook.data.repository.impl
 
-import com.seom.accountbook.data.entity.category.CategoryEntity
-import com.seom.accountbook.data.local.CategoryDao
-import com.seom.accountbook.data.repository.CategoryRepository
-import com.seom.accountbook.di.provideCategoryDao
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.method.MethodEntity
+import com.seom.accountbook.data.local.MethodDao
+import com.seom.accountbook.data.repository.MethodRepository
+import com.seom.accountbook.di.provideMethodDao
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import com.seom.accountbook.data.entity.Result
 
-class CategoryRepositoryImpl(
-    private val categoryDao: CategoryDao = provideCategoryDao(),
+class MethodRepositoryImpl(
+    private val methodDao: MethodDao = provideMethodDao(),
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
-) : CategoryRepository {
-    override suspend fun addCategory(category: CategoryEntity): Result<Long> =
-        withContext(ioDispatcher) {
+) : MethodRepository {
+    override suspend fun addMethod(method: MethodEntity): Result<Long> =
+        withContext(ioDispatcher)
+        {
             try {
-                val categoryId = categoryDao.addCategory(category)
+                val methodId = methodDao.addMethod(method)
 
-                if (categoryId != null) Result.Success(categoryId)
+                if (methodId != null) Result.Success(methodId)
                 else throw Exception("")
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }
         }
 
-    override suspend fun updateCategory(category: CategoryEntity): Result<Int> =
+    override suspend fun updateMethod(method: MethodEntity): Result<Int>  =
         withContext(ioDispatcher) {
             try {
-                val result = categoryDao.updateCategory(category)
+                val result = methodDao.updateMethod(method)
 
                 if (result > 0) Result.Success(result)
                 else throw Exception("")
@@ -37,10 +38,10 @@ class CategoryRepositoryImpl(
             }
         }
 
-    override suspend fun getCategory(id: Long): Result<CategoryEntity> =
+    override suspend fun getMethod(id: Long): Result<MethodEntity> =
         withContext(ioDispatcher) {
             try {
-                val category = categoryDao.getCategory(id)
+                val category = methodDao.getMethods(id)
 
                 if (category != null) Result.Success(category)
                 else throw Exception("")
@@ -48,13 +49,12 @@ class CategoryRepositoryImpl(
                 Result.Error(exception.toString())
             }
         }
-
-    override suspend fun getAllCategories(): Result<List<CategoryEntity>> =
+    override suspend fun getAllMethods(): Result<List<MethodEntity>> =
         withContext(ioDispatcher) {
             try {
-                val categories = categoryDao.getAllCategory()
+                val methods = methodDao.getAllMethods()
 
-                if (categories.isNotEmpty()) Result.Success(categories)
+                if (methods.isNotEmpty()) Result.Success(methods)
                 else throw Exception()
             } catch (exception: Exception) {
                 Result.Error(exception.toString())

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/MethodRepositoryImpl.kt
@@ -26,7 +26,7 @@ class MethodRepositoryImpl(
             }
         }
 
-    override suspend fun updateMethod(method: MethodEntity): Result<Int>  =
+    override suspend fun updateMethod(method: MethodEntity): Result<Int> =
         withContext(ioDispatcher) {
             try {
                 val result = methodDao.updateMethod(method)
@@ -49,13 +49,12 @@ class MethodRepositoryImpl(
                 Result.Error(exception.toString())
             }
         }
+
     override suspend fun getAllMethods(): Result<List<MethodEntity>> =
         withContext(ioDispatcher) {
             try {
                 val methods = methodDao.getAllMethods()
-
-                if (methods.isNotEmpty()) Result.Success(methods)
-                else throw Exception()
+                Result.Success(methods)
             } catch (exception: Exception) {
                 Result.Error(exception.toString())
             }

--- a/app/src/main/java/com/seom/accountbook/di/DataBaseModule.kt
+++ b/app/src/main/java/com/seom/accountbook/di/DataBaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.seom.accountbook.data.local.AccountDao
 import com.seom.accountbook.data.local.AppDatabase
 import com.seom.accountbook.data.local.CategoryDao
+import com.seom.accountbook.data.local.MethodDao
 
 private var appDatabase: AppDatabase? = null
 fun provideAppDatabase(context: Context? = null): AppDatabase {
@@ -21,4 +22,10 @@ private var categoryDao: CategoryDao? = null
 fun provideCategoryDao(): CategoryDao {
     if (categoryDao == null) categoryDao = CategoryDao()
     return categoryDao!!
+}
+
+private var methodDao: MethodDao? = null
+fun provideMethodDao(): MethodDao {
+    if (methodDao == null) methodDao = MethodDao()
+    return methodDao!!
 }

--- a/app/src/main/java/com/seom/accountbook/di/DataBaseModule.kt
+++ b/app/src/main/java/com/seom/accountbook/di/DataBaseModule.kt
@@ -3,6 +3,7 @@ package com.seom.accountbook.di
 import android.content.Context
 import com.seom.accountbook.data.local.AccountDao
 import com.seom.accountbook.data.local.AppDatabase
+import com.seom.accountbook.data.local.CategoryDao
 
 private var appDatabase: AppDatabase? = null
 fun provideAppDatabase(context: Context? = null): AppDatabase {
@@ -14,4 +15,10 @@ private var accountDao: AccountDao? = null
 fun provideAccountDao(): AccountDao {
     if (accountDao == null) accountDao = AccountDao()
     return accountDao!!
+}
+
+private var categoryDao: CategoryDao? = null
+fun provideCategoryDao(): CategoryDao {
+    if (categoryDao == null) categoryDao = CategoryDao()
+    return categoryDao!!
 }

--- a/app/src/main/java/com/seom/accountbook/model/BaseModel.kt
+++ b/app/src/main/java/com/seom/accountbook/model/BaseModel.kt
@@ -1,6 +1,6 @@
 package com.seom.accountbook.model
 
 interface BaseModel{
-    val id: Long
+    val id: Long?
     val name: String
 }

--- a/app/src/main/java/com/seom/accountbook/model/category/CategoryColorPalette.kt
+++ b/app/src/main/java/com/seom/accountbook/model/category/CategoryColorPalette.kt
@@ -1,0 +1,39 @@
+package com.seom.accountbook.model.category
+
+import androidx.compose.ui.graphics.Color
+
+val outcomeColor = listOf(
+    0xFF4A6CC3,
+    0xFF2E86C7,
+    0xFF4CA1DE,
+    0xFF48C2E9,
+    0xFF6ED5EB,
+    0xFF9FE7C8,
+    0xFF94D3CC,
+    0xFF4CB8B8,
+    0xFF40B98D,
+    0xFF2FA488,
+    0xFF625EBA,
+    0xFF817DCE,
+    0xFF9B7DCE,
+    0xFFB391EB,
+    0xFFD092E2,
+    0xFFF1B4EF,
+    0xFFF4AEE1,
+    0xFFF396B8,
+    0xFFDC5D7B,
+    0xFFCB588F
+)
+
+val incomeColor = listOf(
+    0xFF9BD182,
+    0xFFA3CB7A,
+    0xFFB5CC7A,
+    0xFFCCD67A,
+    0xFFEAE07C,
+    0xFFEDCF65,
+    0xFFEBC374,
+    0xFFE1AD60,
+    0xFFE29C4D,
+    0xFFE39145
+)

--- a/app/src/main/java/com/seom/accountbook/model/history/HistoryType.kt
+++ b/app/src/main/java/com/seom/accountbook/model/history/HistoryType.kt
@@ -1,15 +1,19 @@
 package com.seom.accountbook.model.history
 
 import androidx.annotation.StringRes
+import androidx.compose.ui.layout.IntrinsicMeasurable
 import com.seom.accountbook.R
+import com.seom.accountbook.model.category.incomeColor
+import com.seom.accountbook.model.category.outcomeColor
 
 enum class HistoryType(
     val type: Int, // 0: Income, 1: Outcome
     @StringRes
-    val title: Int
+    val title: Int,
+    val colorList: List<Long>
 ) {
-    INCOME(0, R.string.type_history_income),
-    OUTCOME(1, R.string.type_history_outcome);
+    INCOME(0, R.string.type_history_income, incomeColor),
+    OUTCOME(1, R.string.type_history_outcome, outcomeColor);
 
     companion object {
         fun getHistoryType(typeId: Int) = values().find { it.type == typeId } ?: INCOME

--- a/app/src/main/java/com/seom/accountbook/model/post/PostModel.kt
+++ b/app/src/main/java/com/seom/accountbook/model/post/PostModel.kt
@@ -1,0 +1,10 @@
+package com.seom.accountbook.model.post
+
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.account.AccountEntity
+import com.seom.accountbook.model.setting.SettingModel
+
+data class PostModel(
+    val account: Result<AccountEntity>?,
+    val settingModel: SettingModel
+)

--- a/app/src/main/java/com/seom/accountbook/model/setting/SettingModel.kt
+++ b/app/src/main/java/com/seom/accountbook/model/setting/SettingModel.kt
@@ -1,0 +1,10 @@
+package com.seom.accountbook.model.setting
+
+import com.seom.accountbook.data.entity.category.CategoryEntity
+import com.seom.accountbook.data.entity.method.MethodEntity
+import com.seom.accountbook.data.entity.Result
+
+data class SettingModel(
+    val methods: Result<List<MethodEntity>>,
+    val categories: Result<List<CategoryEntity>>
+)

--- a/app/src/main/java/com/seom/accountbook/ui/screen/post/PostScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/post/PostScreen.kt
@@ -100,7 +100,7 @@ fun PostScreen(
             topBar = {
                 BackButtonAppBar(
                     title = if (isModifyMode) "내역 수정" else "내역 등록",
-                    onClickBackBtn = { onBackButtonPressed() }
+                    onClickBackBtn = onBackButtonPressed
                 )
             }
         ) {

--- a/app/src/main/java/com/seom/accountbook/ui/screen/post/PostScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/post/PostScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.seom.accountbook.Category
 import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.category.CategoryEntity
+import com.seom.accountbook.data.entity.method.MethodEntity
 import com.seom.accountbook.model.BaseModel
 import com.seom.accountbook.model.category.CategoryModel
 import com.seom.accountbook.model.history.HistoryType
@@ -35,9 +37,6 @@ import com.seom.accountbook.model.method.MethodModel
 import com.seom.accountbook.ui.components.BackButtonAppBar
 import com.seom.accountbook.ui.components.CustomBottomSheet
 import com.seom.accountbook.ui.components.datesheet.FullDateBottomSheet
-import com.seom.accountbook.ui.screen.setting.incomeMock
-import com.seom.accountbook.ui.screen.setting.methodMock
-import com.seom.accountbook.ui.screen.setting.outcomeMock
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.*
 import kotlinx.coroutines.coroutineScope
@@ -50,7 +49,6 @@ import java.util.*
  */
 
 @RequiresApi(Build.VERSION_CODES.O)
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun PostScreen(
     postId: String? = null,
@@ -59,14 +57,35 @@ fun PostScreen(
 ) {
     val isModifyMode = postId.isNullOrBlank().not()
     val observeData = viewModel.postUiState.collectAsState()
-    when (observeData.value) {
+    when (val result = observeData.value) {
         PostUiState.UnInitialized -> viewModel.fetchAccount(postId = postId?.toLong())
         PostUiState.Loading -> {}
-        PostUiState.Success.FetchAccount -> {}
+        is PostUiState.Success.FetchAccount -> {
+            Body(
+                isModifyMode = isModifyMode,
+                viewModel = viewModel,
+                methods = result.methods,
+                incomeCategories = result.incomeCategories,
+                outcomeCategories = result.outcomeCategories,
+                onBackButtonPressed = onBackButtonPressed
+            )
+        }
         PostUiState.Success.AddAccount -> onBackButtonPressed()
         is PostUiState.Error -> {}
     }
+}
 
+@RequiresApi(Build.VERSION_CODES.O)
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun Body(
+    isModifyMode: Boolean,
+    viewModel: PostViewModel,
+    methods: List<MethodEntity>,
+    incomeCategories: List<CategoryEntity>,
+    outcomeCategories: List<CategoryEntity>,
+    onBackButtonPressed: () -> Unit
+) {
     val bottomSheetState =
         rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
@@ -115,8 +134,8 @@ fun PostScreen(
                 )
                 PostBody(
                     isModifyMode = isModifyMode,
-                    methods = methodMock,
-                    categories = if (type.value == HistoryType.INCOME) incomeMock else outcomeMock,
+                    methods = methods,
+                    categories = if (type.value == HistoryType.INCOME) incomeCategories else outcomeCategories,
                     currentSelectedTab = type,
                     openDatePicker = {
                         coroutineScope.launch {
@@ -139,6 +158,7 @@ fun PostScreen(
         }
     }
 }
+
 
 // TODO 재활용할 수 있도록 수정하자
 @Composable
@@ -200,17 +220,17 @@ fun HistoryTypeItm(
 @Composable
 fun PostBody(
     isModifyMode: Boolean,
-    methods: List<MethodModel>,
-    categories: List<CategoryModel>,
+    methods: List<MethodEntity>,
+    categories: List<CategoryEntity>,
     currentSelectedTab: State<HistoryType>,
     openDatePicker: () -> Unit,
     date: State<LocalDate>,
     count: State<Int>,
     onChangeCount: (Int) -> Unit,
     methodId: State<Long?>,
-    onChangeMethodId: (Long) -> Unit,
+    onChangeMethodId: (Long?) -> Unit,
     categoryId: State<Long?>,
-    onChangeCategoryId: (Long) -> Unit,
+    onChangeCategoryId: (Long?) -> Unit,
     content: State<String>,
     onChangeContent: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -381,7 +401,7 @@ fun ContentInput(
 @Composable
 fun ExposedDropdownBox(
     selectedOptionId: Long,
-    onOptionSelected: (Long) -> Unit,
+    onOptionSelected: (Long?) -> Unit,
     options: List<BaseModel>
 ) {
     var expanded by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,34 +26,40 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.category.CategoryEntity
+import com.seom.accountbook.data.entity.method.MethodEntity
 import com.seom.accountbook.model.category.CategoryModel
 import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.model.method.MethodModel
 import com.seom.accountbook.ui.theme.ColorPalette
 
-val methodMock = listOf(
-    MethodModel(id = 0, name = "현대카드"),
-    MethodModel(id = 1, name = "카카오뱅크 체크카드")
-)
-
-val outcomeMock = listOf(
-    CategoryModel(id = 0, name = "교통", categoryColor = 0xFF94D3CC),
-    CategoryModel(id = 1, name = "문화/여가", categoryColor = 0xFFD092E2),
-    CategoryModel(id = 2, name = "미분류", categoryColor = 0xFF817DCE),
-    CategoryModel(id = 3, name = "생활", categoryColor = 0xFF4A6CC3),
-    CategoryModel(id = 4, name = "쇼핑/뷰티", categoryColor = 0xFF4CB8B8),
-    CategoryModel(id = 5, name = "식비", categoryColor = 0xFF4CA1DE),
-    CategoryModel(id = 6, name = "의료/건강", categoryColor = 0xFF6ED5EB)
-)
-
-val incomeMock = listOf(
-    CategoryModel(id = 0, name = "월급", categoryColor = 0xFF9BD182),
-    CategoryModel(id = 1, name = "용돈", categoryColor = 0xFFEDCF65),
-    CategoryModel(id = 2, name = "기타", categoryColor = 0xFFE29C4D)
-)
-
 @Composable
 fun SettingScreen(
+    viewModel: SettingViewModel,
+    onPushNavigate: (String, String) -> Unit
+) {
+    val observeData = viewModel.settingUiState.collectAsState()
+    when (val result = observeData.value) {
+        SettingUiState.UnInitialized -> viewModel.fetchData()
+        SettingUiState.Loading -> {}
+        is SettingUiState.Success -> {
+            Body(
+                methods = result.methods,
+                incomeCategories = result.incomeCategories,
+                outcomeCategories = result.outcomeCategories,
+                onPushNavigate = onPushNavigate
+            )
+        }
+        is SettingUiState.Error -> {}
+    }
+
+}
+
+@Composable
+fun Body(
+    methods: List<MethodEntity>,
+    incomeCategories: List<CategoryEntity>,
+    outcomeCategories: List<CategoryEntity>,
     onPushNavigate: (String, String) -> Unit
 ) {
     Scaffold(
@@ -79,7 +86,7 @@ fun SettingScreen(
 
             LazyColumn {
                 stickyHeader { Header(title = "결제수단") }
-                items(items = methodMock) {
+                items(items = methods) {
                     MethodItem(method = it) {
                         onPushNavigate(
                             com.seom.accountbook.Method.route,
@@ -97,7 +104,7 @@ fun SettingScreen(
                 }
                 item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
                 stickyHeader { Header(title = "지출 카테고리") }
-                items(items = outcomeMock) {
+                items(items = outcomeCategories) {
                     CategoryItem(category = it) {
                         onPushNavigate(
                             com.seom.accountbook.Category.route,
@@ -115,7 +122,7 @@ fun SettingScreen(
                 }
                 item { Divider(color = ColorPalette.LightPurple, thickness = 1.dp) }
                 stickyHeader { Header(title = "수입 카테고리") }
-                items(items = incomeMock) {
+                items(items = incomeCategories) {
                     CategoryItem(category = it) {
                         onPushNavigate(
                             com.seom.accountbook.Category.route,
@@ -162,8 +169,8 @@ fun Header(
 
 @Composable
 fun MethodItem(
-    method: MethodModel,
-    onClickItem: (Long) -> Unit
+    method: MethodEntity,
+    onClickItem: (Long?) -> Unit
 ) {
     Column(
         modifier = Modifier.padding(start = 16.dp, end = 16.dp)
@@ -186,8 +193,8 @@ fun MethodItem(
 
 @Composable
 fun CategoryItem(
-    category: CategoryModel,
-    onClickItem: (Long) -> Unit
+    category: CategoryEntity,
+    onClickItem: (Long?) -> Unit
 ) {
     Column(
         modifier = Modifier.padding(start = 16.dp, end = 16.dp)
@@ -214,7 +221,7 @@ fun CategoryItem(
                 modifier = Modifier
                     .widthIn(56.dp)
                     .clip(RoundedCornerShape(999.dp))
-                    .background(Color(category.categoryColor))
+                    .background(Color(category.color))
                     .padding(start = 8.dp, top = 4.dp, end = 8.dp, bottom = 4.dp),
                 textAlign = TextAlign.Center
             )

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/SettingViewModel.kt
@@ -1,0 +1,65 @@
+package com.seom.accountbook.ui.screen.setting
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.category.CategoryEntity
+import com.seom.accountbook.data.entity.method.MethodEntity
+import com.seom.accountbook.model.category.CategoryModel
+import com.seom.accountbook.model.history.HistoryType
+import com.seom.accountbook.model.method.MethodModel
+import com.seom.accountbook.model.setting.SettingModel
+import com.seom.accountbook.usecase.GetAllSettingDataUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class SettingViewModel(
+    private val getAllSettingDataUseCase: GetAllSettingDataUseCase = GetAllSettingDataUseCase()
+) : ViewModel() {
+    private val _settingUiState = MutableStateFlow<SettingUiState>(SettingUiState.UnInitialized)
+    val settingUiState: StateFlow<SettingUiState>
+        get() = _settingUiState
+
+    fun fetchData() = viewModelScope.launch {
+        val result = getAllSettingDataUseCase()
+
+        val methods = when (val methodResult = result.methods) {
+            is Result.Error -> {
+                _settingUiState.value = SettingUiState.Error(R.string.error_setting_method_get)
+                emptyList()
+            }
+            is Result.Success -> methodResult.data
+        }
+        val categories = when (val categoryResult = result.categories) {
+            is Result.Error -> {
+                _settingUiState.value = SettingUiState.Error(R.string.error_setting_category_get)
+                emptyList()
+            }
+            is Result.Success -> categoryResult.data
+        }
+
+        _settingUiState.value = SettingUiState.Success(
+            methods = methods,
+            incomeCategories = categories.filter { it.type == HistoryType.INCOME.type },
+            outcomeCategories = categories.filter { it.type == HistoryType.OUTCOME.type }
+        )
+    }
+}
+
+sealed interface SettingUiState {
+    object UnInitialized : SettingUiState
+    object Loading : SettingUiState
+    data class Success(
+        val methods: List<MethodEntity>,
+        val incomeCategories: List<CategoryEntity>,
+        val outcomeCategories: List<CategoryEntity>
+    ) : SettingUiState
+
+    data class Error(
+        @StringRes
+        val errorMsg: Int
+    ) : SettingUiState
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -44,10 +44,9 @@ fun CategoryAddScreen(
         CategoryUiState.Success.FetchCategory -> SettingBody(
             viewModel = viewModel,
             isModifyMode = categoryId.isNullOrBlank().not(),
-            categoryType = categoryType
-        ) {
-
-        }
+            categoryType = categoryType,
+            onBackButtonPressed = onBackButtonPressed
+        )
         is CategoryUiState.Error -> {}
     }
 

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryAddScreen.kt
@@ -10,85 +10,75 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import com.seom.accountbook.R
+import com.seom.accountbook.model.category.incomeColor
+import com.seom.accountbook.model.category.outcomeColor
 import com.seom.accountbook.model.history.HistoryType
+import com.seom.accountbook.ui.components.BackButtonAppBar
 import com.seom.accountbook.ui.components.OneButtonAppBar
 import com.seom.accountbook.ui.screen.setting.method.Input
 import com.seom.accountbook.ui.screen.setting.method.InputField
 import com.seom.accountbook.ui.theme.ColorPalette
 import kotlin.math.min
 
-val outcomeColor = listOf(
-    Color(0xFF4A6CC3),
-    Color(0xFF2E86C7),
-    Color(0xFF4CA1DE),
-    Color(0xFF48C2E9),
-    Color(0xFF6ED5EB),
-    Color(0xFF9FE7C8),
-    Color(0xFF94D3CC),
-    Color(0xFF4CB8B8),
-    Color(0xFF40B98D),
-    Color(0xFF2FA488),
-    Color(0xFF625EBA),
-    Color(0xFF817DCE),
-    Color(0xFF9B7DCE),
-    Color(0xFFB391EB),
-    Color(0xFFD092E2),
-    Color(0xFFF1B4EF),
-    Color(0xFFF4AEE1),
-    Color(0xFFF396B8),
-    Color(0xFFDC5D7B),
-    Color(0xFFCB588F)
-)
-
-val incomeColor = listOf(
-    Color(0xFF9BD182),
-    Color(0xFFA3CB7A),
-    Color(0xFFB5CC7A),
-    Color(0xFFCCD67A),
-    Color(0xFFEAE07C),
-    Color(0xFFEDCF65),
-    Color(0xFFEBC374),
-    Color(0xFFE1AD60),
-    Color(0xFFE29C4D),
-    Color(0xFFE39145)
-)
-
 @Composable
 fun CategoryAddScreen(
     categoryId: String? = null,
     categoryType: HistoryType,
+    viewModel: CategoryViewModel,
     onBackButtonPressed: () -> Unit
 ) {
-    val title = if (categoryType == HistoryType.INCOME) "수입" else "지출"
-    val modeTitle = if (categoryId.isNullOrBlank()) "추가하기" else "수정하기"
-    val colorList = if (categoryType == HistoryType.INCOME) incomeColor else outcomeColor
+    val observeData = viewModel.categoryUiState.collectAsState()
+    when (observeData.value) {
+        CategoryUiState.UnInitialized -> viewModel.fetchCategory(
+            categoryId = categoryId?.toLong(),
+            categoryType = categoryType
+        )
+        CategoryUiState.Loading -> {}
+        CategoryUiState.Success.AddCategory -> onBackButtonPressed()
+        CategoryUiState.Success.FetchCategory -> SettingBody(
+            viewModel = viewModel,
+            isModifyMode = categoryId.isNullOrBlank().not(),
+            categoryType = categoryType
+        ) {
 
-    var name by remember { mutableStateOf("") }
-    var selectedIndex by remember { mutableStateOf(0) }
+        }
+        is CategoryUiState.Error -> {}
+    }
+
+
+}
+
+@Composable
+fun SettingBody(
+    viewModel: CategoryViewModel,
+    isModifyMode: Boolean,
+    categoryType: HistoryType,
+    onBackButtonPressed: ()->Unit
+) {
+    val title = if (categoryType == HistoryType.INCOME) "수입" else "지출"
+    val modeTitle = if (isModifyMode) "추가하기" else "수정하기"
+
+    val name = viewModel.name.collectAsState()
+    val color = viewModel.color.collectAsState()
 
     Scaffold(topBar = {
-        OneButtonAppBar(title = "$title 카테고리 $modeTitle") {
-            Image(
-                painter = painterResource(id = R.drawable.ic_back),
-                contentDescription = null,
-                modifier = Modifier.clickable { onBackButtonPressed() })
-        }
+        BackButtonAppBar(
+            title = "$title 카테고리 $modeTitle",
+            onClickBackBtn = onBackButtonPressed
+        )
     }) {
         Box(
             modifier = Modifier.fillMaxSize()
         ) {
-            Divider(
-                color = ColorPalette.Purple,
-                thickness = 1.dp
-            )
             Column {
                 InputField(title = "이름") {
-                    Input(content = name, onValueChange = { name = it })
+                    Input(content = name.value, onValueChange = viewModel::setName)
                 }
                 Spacer(modifier = Modifier.height(16.dp))
                 Column(
@@ -105,15 +95,18 @@ fun CategoryAddScreen(
                     Divider(color = ColorPalette.Purple40, thickness = 1.dp)
                 }
 
-                ColorSelector(colors = colorList, perLine = 10, selectedIndex = selectedIndex) {
-                    selectedIndex = it
-                }
+                ColorSelector(
+                    colors = viewModel.colorList,
+                    perLine = 10,
+                    selectedColor = color.value,
+                    onSelectItem = viewModel::setColor
+                )
                 Spacer(modifier = Modifier.height(5.dp))
                 Divider(color = ColorPalette.LightPurple, thickness = 1.dp)
             }
 
             Button(
-                onClick = { onBackButtonPressed() },
+                onClick = viewModel::addCategory,
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .fillMaxWidth()
@@ -122,7 +115,7 @@ fun CategoryAddScreen(
                     backgroundColor = ColorPalette.Yellow,
                     disabledBackgroundColor = ColorPalette.Yellow50
                 ),
-                enabled = name.isNullOrBlank().not()
+                enabled = name.value.isBlank().not()
             ) {
                 Text(
                     text = "등록하기",
@@ -136,17 +129,16 @@ fun CategoryAddScreen(
                 )
             }
         }
-
     }
 }
 
 @Composable
 fun ColorSelector(
-    colors: List<Color>,
+    colors: List<Long>,
     perLine: Int,
-    selectedIndex: Int,
+    selectedColor: Long,
     modifier: Modifier = Modifier,
-    onSelectItem: (Int) -> Unit
+    onSelectItem: (Long) -> Unit
 ) {
     var rowNum = colors.size / perLine
     if (colors.size % perLine != 0)
@@ -159,13 +151,14 @@ fun ColorSelector(
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
                 (0 until min(perLine, colors.size)).forEachIndexed { _, column ->
-                    val paddingAnimation by animateDpAsState(targetValue = if (row * perLine + column == selectedIndex) 0.dp else 4.dp)
+                    val color = colors[row * perLine + column]
+                    val paddingAnimation by animateDpAsState(targetValue = if (color == selectedColor) 0.dp else 4.dp)
                     Spacer(
                         modifier = Modifier
                             .size(24.dp)
                             .padding(paddingAnimation)
-                            .background(colors[row * perLine + column])
-                            .clickable { onSelectItem(row * perLine + column) }
+                            .background(Color(color))
+                            .clickable { onSelectItem(color) }
                     )
                 }
             }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryViewModel.kt
@@ -9,6 +9,8 @@ import com.seom.accountbook.data.entity.Result
 import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.repository.CategoryRepository
 import com.seom.accountbook.data.repository.impl.CategoryRepositoryImpl
+import com.seom.accountbook.model.category.incomeColor
+import com.seom.accountbook.model.category.outcomeColor
 import com.seom.accountbook.model.history.HistoryType
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +26,10 @@ class CategoryViewModel(
         get() = _categoryUiState
 
     private var currentCategoryId: Long? = null
-    private var currentCategoryType: HistoryType? = null
+    private var currentCategoryType = HistoryType.INCOME
+
+    val colorList
+        get() = currentCategoryType.colorList
 
     // 카테고리 페이지에 필요한 데이터
     private val _name = MutableStateFlow("")
@@ -33,7 +38,7 @@ class CategoryViewModel(
         _name.value = newName
     }
 
-    private val _color = MutableStateFlow(0L)
+    private val _color = MutableStateFlow<Long>(0L)
     var color = _color.asStateFlow()
     fun setColor(newColor: Long) {
         _color.value = newColor
@@ -42,6 +47,7 @@ class CategoryViewModel(
     fun fetchCategory(categoryId: Long?, categoryType: HistoryType) = viewModelScope.launch {
         currentCategoryType = categoryType
         if (categoryId == null) {
+            _color.value = colorList[0]
             _categoryUiState.value = CategoryUiState.Success.FetchCategory
         } else {
             _categoryUiState.value = CategoryUiState.Loading
@@ -64,7 +70,7 @@ class CategoryViewModel(
         val category = CategoryEntity(
             id = currentCategoryId,
             name = name.value,
-            color = color.value,
+            color = color.value!!,
             type = currentCategoryType?.type ?: HistoryType.INCOME.type
         )
 

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/category/CategoryViewModel.kt
@@ -1,0 +1,97 @@
+package com.seom.accountbook.ui.screen.setting.category
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.category.CategoryEntity
+import com.seom.accountbook.data.repository.CategoryRepository
+import com.seom.accountbook.data.repository.impl.CategoryRepositoryImpl
+import com.seom.accountbook.model.history.HistoryType
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class CategoryViewModel(
+    private val categoryRepository: CategoryRepository = CategoryRepositoryImpl()
+) : ViewModel() {
+    private val _categoryUiState = MutableStateFlow<CategoryUiState>(CategoryUiState.UnInitialized)
+    val categoryUiState: StateFlow<CategoryUiState>
+        get() = _categoryUiState
+
+    private var currentCategoryId: Long? = null
+    private var currentCategoryType: HistoryType? = null
+
+    // 카테고리 페이지에 필요한 데이터
+    private val _name = MutableStateFlow("")
+    var name = _name.asStateFlow()
+    fun setName(newName: String) {
+        _name.value = newName
+    }
+
+    private val _color = MutableStateFlow(0L)
+    var color = _color.asStateFlow()
+    fun setColor(newColor: Long) {
+        _color.value = newColor
+    }
+
+    fun fetchCategory(categoryId: Long?, categoryType: HistoryType) = viewModelScope.launch {
+        currentCategoryType = categoryType
+        if (categoryId == null) {
+            _categoryUiState.value = CategoryUiState.Success.FetchCategory
+        } else {
+            _categoryUiState.value = CategoryUiState.Loading
+            when (val result = categoryRepository.getCategory(categoryId)) {
+                is Result.Error -> _categoryUiState.value =
+                    CategoryUiState.Error(R.string.error_category_get)
+                is Result.Success -> {
+                    val category = result.data
+                    currentCategoryId = category.id
+                    _name.value = category.name
+                    _color.value = category.color
+
+                    _categoryUiState.value = CategoryUiState.Success.FetchCategory
+                }
+            }
+        }
+    }
+
+    fun addCategory() = viewModelScope.launch {
+        val category = CategoryEntity(
+            id = currentCategoryId,
+            name = name.value,
+            color = color.value,
+            type = currentCategoryType?.type ?: HistoryType.INCOME.type
+        )
+
+        val result = currentCategoryId?.let {
+            categoryRepository.updateCategory(category)
+        } ?: kotlin.run {
+            categoryRepository.addCategory(category)
+        }
+
+        when (result) {
+            is Result.Error -> _categoryUiState.value =
+                CategoryUiState.Error(R.string.error_account_add)
+            is Result.Success -> _categoryUiState.value = CategoryUiState.Success.AddCategory
+        }
+    }
+}
+
+sealed interface CategoryUiState {
+    object UnInitialized : CategoryUiState
+    object Loading : CategoryUiState
+    object Success {
+        object AddCategory : CategoryUiState
+        object FetchCategory : CategoryUiState
+    }
+
+    data class Error(
+        @StringRes
+        val errorMsg: Int
+    ) : CategoryUiState
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/setting/method/MethodViewModel.kt
@@ -1,0 +1,83 @@
+package com.seom.accountbook.ui.screen.setting.method
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.method.MethodEntity
+import com.seom.accountbook.data.repository.MethodRepository
+import com.seom.accountbook.data.repository.impl.MethodRepositoryImpl
+import com.seom.accountbook.ui.screen.setting.category.CategoryUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class MethodViewModel(
+    private val methodRepository: MethodRepository = MethodRepositoryImpl()
+) : ViewModel() {
+    private val _methodUiState = MutableStateFlow<MethodUiState>(MethodUiState.UnInitialized)
+    val methodUiState: StateFlow<MethodUiState>
+        get() = _methodUiState
+
+    private var currentMethodId: Long? = null
+
+    private val _name = MutableStateFlow("")
+    var name = _name.asStateFlow()
+    fun setName(newName: String) {
+        _name.value = newName
+    }
+
+    fun fetchCategory(methodId: Long?) = viewModelScope.launch {
+        if (methodId == null) {
+            _methodUiState.value = MethodUiState.Success.FetchMethod
+        } else {
+            _methodUiState.value = MethodUiState.Loading
+            when (val result = methodRepository.getMethod(methodId)) {
+                is Result.Error -> _methodUiState.value =
+                    MethodUiState.Error(R.string.error_method_get)
+                is Result.Success -> {
+                    val method = result.data
+                    currentMethodId = method.id
+                    _name.value = method.name
+
+                    _methodUiState.value = MethodUiState.Success.FetchMethod
+                }
+            }
+        }
+    }
+
+    fun addCategory() = viewModelScope.launch {
+        val method = MethodEntity(
+            id = currentMethodId,
+            name = name.value
+        )
+
+        val result = currentMethodId?.let {
+            methodRepository.updateMethod(method)
+        } ?: kotlin.run {
+            methodRepository.addMethod(method)
+        }
+
+        when (result) {
+            is Result.Error -> _methodUiState.value =
+                MethodUiState.Error(R.string.error_method_add)
+            is Result.Success -> _methodUiState.value = MethodUiState.Success.AddMethod
+        }
+    }
+}
+
+sealed interface MethodUiState {
+    object UnInitialized : MethodUiState
+    object Loading : MethodUiState
+    object Success {
+        object AddMethod : MethodUiState
+        object FetchMethod : MethodUiState
+    }
+
+    data class Error(
+        @StringRes
+        val errorMsg: Int
+    ) : MethodUiState
+}

--- a/app/src/main/java/com/seom/accountbook/usecase/GetAllSettingDataUseCase.kt
+++ b/app/src/main/java/com/seom/accountbook/usecase/GetAllSettingDataUseCase.kt
@@ -1,0 +1,26 @@
+package com.seom.accountbook.usecase
+
+import com.seom.accountbook.data.repository.CategoryRepository
+import com.seom.accountbook.data.repository.MethodRepository
+import com.seom.accountbook.data.repository.impl.CategoryRepositoryImpl
+import com.seom.accountbook.data.repository.impl.MethodRepositoryImpl
+import com.seom.accountbook.model.setting.SettingModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+class GetAllSettingDataUseCase(
+    private val methodRepository: MethodRepository = MethodRepositoryImpl(),
+    private val categoryRepository: CategoryRepository = CategoryRepositoryImpl()
+) : UseCase {
+
+    suspend operator fun invoke(): SettingModel =
+        coroutineScope {
+            val categories = async { categoryRepository.getAllCategories() }
+            val methods = async { methodRepository.getAllMethods() }
+
+            SettingModel(
+                methods = methods.await(),
+                categories = categories.await()
+            )
+        }
+}

--- a/app/src/main/java/com/seom/accountbook/usecase/GetPostDataUseCase.kt
+++ b/app/src/main/java/com/seom/accountbook/usecase/GetPostDataUseCase.kt
@@ -1,0 +1,24 @@
+package com.seom.accountbook.usecase
+
+import com.seom.accountbook.data.repository.AccountRepository
+import com.seom.accountbook.data.repository.impl.AccountRepositoryImpl
+import com.seom.accountbook.model.post.PostModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+class GetPostDataUseCase(
+    private val accountRepository: AccountRepository = AccountRepositoryImpl(),
+    private val getAllSettingDataUseCase: GetAllSettingDataUseCase = GetAllSettingDataUseCase()
+) {
+    suspend operator fun invoke(id: Long?): PostModel =
+        coroutineScope {
+            val account =
+                id?.let { async { accountRepository.getAccount(id) } } ?: kotlin.run { null }
+            val settings = async { getAllSettingDataUseCase() }
+
+            PostModel(
+                account = account?.await(),
+                settingModel = settings.await()
+            )
+        }
+}

--- a/app/src/main/java/com/seom/accountbook/usecase/UseCase.kt
+++ b/app/src/main/java/com/seom/accountbook/usecase/UseCase.kt
@@ -1,0 +1,3 @@
+package com.seom.accountbook.usecase
+
+interface UseCase {}

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -55,7 +55,9 @@ fun AccountNavigationHost(
             )
         }
         composable(route = Setting.route) {
-            SettingScreen { route, args ->
+            SettingScreen(
+                viewModel = viewModel()
+            ) { route, args ->
                 navController.navigateSingleTop(route, args)
             }
         }

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -114,6 +114,7 @@ fun AccountNavigationHost(
             CategoryAddScreen(
                 null,
                 HistoryType.getHistoryType(categoryType?.toInt() ?: 0),
+                viewModel = viewModel()
             ) {
                 navController.popBackStack()
             }
@@ -128,6 +129,7 @@ fun AccountNavigationHost(
             CategoryAddScreen(
                 categoryId,
                 HistoryType.getHistoryType(categoryType?.toInt() ?: 0),
+                viewModel = viewModel()
             ) {
                 navController.popBackStack()
             }

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -93,7 +93,9 @@ fun AccountNavigationHost(
         composable(
             route = Method.route
         ) {
-            MethodAddScreen {
+            MethodAddScreen(
+                viewModel = viewModel()
+            ) {
                 navController.popBackStack()
             }
         }
@@ -103,7 +105,10 @@ fun AccountNavigationHost(
             arguments = Method.arguments
         ) { navBackStackEntry ->
             val methodId = navBackStackEntry.arguments?.getString(Method.methodIdArgs)
-            MethodAddScreen(methodId) {
+            MethodAddScreen(
+                methodId = methodId,
+                viewModel = viewModel()
+            ) {
                 navController.popBackStack()
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,12 @@
     <!-- history -->
     <string name="type_history_income">수입</string>
     <string name="type_history_outcome">지출</string>
+
+    <!-- post -->
     <string name="error_account_add">정보를 저장하는 도중 문제가 발생했어요.ð</string>
     <string name="error_account_get">정보를 가져오는 도중 문제가 발생했어요.ð</string>
+
+    <!-- category -->
+    <string name="error_category_add">카테고리를 추가하는 도중 문제가 발생했어요.</string>
+    <string name="error_category_get">카테고리 정보를 가져오는 도중 문제가 발생했어요.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,9 @@
     <!-- setting -->
     <string name="error_setting_method_get">결제수단 정보를 가져오는 도중 문제가 발생하였습니다.</string>
     <string name="error_setting_category_get">카테고리 정보를 가져오는 도중 문제가 발생하였습니다.</string>
+
+    <!-- method -->
+    <string name="error_method_add">결제 수단 정보를 추가하는 도중 문제가 발생했어요.</string>
+    <string name="error_method_get">결제 수단 정보를 가져오는 도중 문제가 발생했어요.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,8 @@
     <!-- category -->
     <string name="error_category_add">카테고리를 추가하는 도중 문제가 발생했어요.</string>
     <string name="error_category_get">카테고리 정보를 가져오는 도중 문제가 발생했어요.</string>
+
+    <!-- setting -->
+    <string name="error_setting_method_get">결제수단 정보를 가져오는 도중 문제가 발생하였습니다.</string>
+    <string name="error_setting_category_get">카테고리 정보를 가져오는 도중 문제가 발생하였습니다.</string>
 </resources>


### PR DESCRIPTION
### 📌 Summary
설정 화면의 결제수단 / 지출 카테고리 / 수입 카테고리  CRUD Datalayer단 구성하기

### 🍿 Main Changes
- 결제 수단 CRU 기능을 제공하는 API와 Repository 구성
- 수입/지출 카테고리 CRU 기능을 제공하는 API와 Repository 구성
- Repository / viewModel / view 연동
- 결제 수단과 수입/지출 카테고리 기본 데이터를 데이터베이스 생성 시 추가
- 수입/지출 작성 화면에 해당 데이터 연동

### 🔥 UseCase
1. 수입/지출 카테고리 추가/변경
2. 결제 수단 추가/변경
3. 화면은 PR #21 과 동일

### 🛠 Related Issue
Closes #25
