### PR TITLE
달력 화면(calendar화면) Database와 연동하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/data/entity/calendar/CalendarEntity.kt
+++ b/app/src/main/java/com/seom/accountbook/data/entity/calendar/CalendarEntity.kt
@@ -1,0 +1,7 @@
+package com.seom.accountbook.data.entity.calendar
+
+data class CalendarEntity(
+    val date: Int,
+    val count: Int,
+    val type: Int
+)

--- a/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
@@ -5,6 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.provider.BaseColumns
 import androidx.core.database.getLongOrNull
 import com.seom.accountbook.data.entity.account.AccountEntity
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.entity.method.MethodEntity
 import com.seom.accountbook.di.provideAppDatabase
@@ -175,5 +176,34 @@ class AccountDao(
 
         val numRowsDeleted = db.delete(TABLE_NAME, whereClause, whereArgs)
         return numRowsDeleted
+    }
+
+    fun getAllAccountOnDate(year: Int, month: Int): List<CalendarEntity> {
+        val db = appDatabase.writable
+        val query = "SELECT " +
+                "${AccountEntity.COLUMN_NAME_DATE}," +
+                "SUM(${AccountEntity.COLUMN_NAME_COUNT})," +
+                "${AccountEntity.COLUMN_NAME_TYPE} " +
+                "FROM ${TABLE_NAME} " +
+                "WHERE ${AccountEntity.COLUMN_NAME_YEAR} = $year " +
+                "AND ${AccountEntity.COLUMN_NAME_MONTH} = $month " +
+                "GROUP BY ${AccountEntity.COLUMN_NAME_TYPE}, ${AccountEntity.COLUMN_NAME_DATE}"
+
+        val cursor = db.rawQuery(query, null)
+
+        val accounts = mutableListOf<CalendarEntity>()
+        if (cursor.moveToFirst()) {
+            do {
+                accounts.add(
+                    CalendarEntity(
+                        date = cursor.getInt(0),
+                        count = cursor.getInt(1),
+                        type = cursor.getInt(2)
+                    )
+                )
+            } while (cursor.moveToNext())
+        }
+
+        return accounts.toList()
     }
 }

--- a/app/src/main/java/com/seom/accountbook/data/repository/AccountRepository.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/AccountRepository.kt
@@ -2,6 +2,7 @@ package com.seom.accountbook.data.repository
 
 import com.seom.accountbook.data.entity.Result
 import com.seom.accountbook.data.entity.account.AccountEntity
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.model.history.HistoryModel
 
 interface AccountRepository {
@@ -19,4 +20,7 @@ interface AccountRepository {
 
     // 특정 수입/지출 내역 제거
     suspend fun removeAccounts(accountItems: List<Long>): Result<Int>
+
+    // 일별 수입/지출 내역 가져오기
+    suspend fun getAllAccountOnDate(year: Int, month: Int): Result<List<CalendarEntity>>
 }

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.model.history.HistoryModel
 
 class AccountRepositoryImpl(
@@ -65,6 +66,17 @@ class AccountRepositoryImpl(
                 val deletedRowNum = accountDao.removeAccount(accountItems)
                 Result.Success(deletedRowNum)
             } catch (exception: Exception) {
+                Result.Error(exception.toString())
+            }
+        }
+
+    override suspend fun getAllAccountOnDate(year: Int, month: Int): Result<List<CalendarEntity>> =
+        withContext(ioDispatcher) {
+            try {
+                val result = accountDao.getAllAccountOnDate(year, month)
+                Result.Success(result)
+            } catch (exception: Exception) {
+                println(exception.toString())
                 Result.Error(exception.toString())
             }
         }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarScreen.kt
@@ -44,6 +44,7 @@ fun CalendarScreen(
     onPushNavigate: (String, String) -> Unit
 ) {
     var histories by remember { mutableStateOf<List<CalendarEntity>>(emptyList()) }
+    val calendarState = rememberCalendarState()
 
     val observer = viewModel.categoryUiState.collectAsState()
     when (val result = observer.value) {
@@ -57,12 +58,10 @@ fun CalendarScreen(
         CalendarUiState.Loading -> {}
         is CalendarUiState.SuccessFetch -> {
             histories = result.accounts
-            println(histories)
         }
         is CalendarUiState.Error -> {}
     }
 
-    val calendarState = rememberCalendarState()
     val calendarDate = histories.groupBy { it.date }
     val income = histories.filter { it.type == HistoryType.INCOME.type }.sumOf { it.count }
     val outcome = histories.filter { it.type == HistoryType.OUTCOME.type }.sumOf { it.count }
@@ -70,6 +69,7 @@ fun CalendarScreen(
     DateAppBar(
         onDateChange = {
             // TODO 변경된 날짜에 맞는 데이터 요청
+            viewModel.fetchData(it.year, it.month.value)
             calendarState.monthState.currentMonth = YearMonth.from(it)
         },
         children = {
@@ -167,7 +167,7 @@ fun RowData(
                 )
             )
             Text(
-                text = data.toMoney(),
+                text = "${data.toMoney()} 원",
                 style = MaterialTheme.typography.caption.copy(
                     color = dateColor
                 )

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/CalendarViewModel.kt
@@ -1,0 +1,45 @@
+package com.seom.accountbook.ui.screen.calendar
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
+import com.seom.accountbook.data.repository.AccountRepository
+import com.seom.accountbook.data.repository.impl.AccountRepositoryImpl
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class CalendarViewModel(
+    private val accountRepository: AccountRepository = AccountRepositoryImpl()
+) : ViewModel() {
+    private val _categoryUiState = MutableStateFlow<CalendarUiState>(CalendarUiState.UnInitialized)
+    val categoryUiState: StateFlow<CalendarUiState>
+        get() = _categoryUiState
+
+    fun fetchData(year: Int, month: Int) = viewModelScope.launch {
+        _categoryUiState.value = CalendarUiState.Loading
+        when (val result = accountRepository.getAllAccountOnDate(year, month)) {
+            is Result.Error -> _categoryUiState.value =
+                CalendarUiState.Error(R.string.error_history_get)
+            is Result.Success -> _categoryUiState.value =
+                CalendarUiState.SuccessFetch(result.data)
+        }
+    }
+}
+
+sealed interface CalendarUiState {
+    object UnInitialized : CalendarUiState
+    object Loading : CalendarUiState
+
+    data class SuccessFetch(
+        val accounts: List<CalendarEntity>
+    ) : CalendarUiState
+
+    data class Error(
+        @StringRes
+        val errorMsg: Int
+    ) : CalendarUiState
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/day/DefaultDay.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/day/DefaultDay.kt
@@ -1,5 +1,7 @@
 package com.seom.accountbook.ui.screen.calendar.day
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Card
@@ -15,15 +17,24 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
+import com.seom.accountbook.model.history.HistoryType
 import com.seom.accountbook.ui.theme.ColorPalette
+import com.seom.accountbook.util.ext.toMoney
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun DefaultDate(
+    account: Map<Int, List<CalendarEntity>>,
     state: DayState,
     modifier: Modifier = Modifier,
     currentDayColor: Color = ColorPalette.White
 ) {
     val date = state.date
+
+    val come = account[date.dayOfMonth]
+    val income = come?.find { it.type == HistoryType.INCOME.type }?.count ?: 0
+    val outcome = come?.find { it.type == HistoryType.OUTCOME.type }?.count ?: 0
 
     Card(
         modifier = Modifier
@@ -41,19 +52,19 @@ fun DefaultDate(
                     modifier = Modifier.align(Alignment.TopStart)
                 ) {
                     Text(
-                        text = "1,500",
+                        text = income.toMoney(),
                         fontWeight = FontWeight(500),
                         color = ColorPalette.Green,
                         fontSize = 8.sp
                     )
                     Text(
-                        text = "-900",
+                        text = (-1 * outcome).toMoney(),
                         fontWeight = FontWeight(500),
                         color = ColorPalette.Red,
                         fontSize = 8.sp
                     )
                     Text(
-                        text = "2,400",
+                        text = (income - outcome).toMoney(),
                         fontWeight = FontWeight(500),
                         color = ColorPalette.Purple,
                         fontSize = 8.sp

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/month/MonthContent.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/month/MonthContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.ui.screen.calendar.day.DayState
 import com.seom.accountbook.ui.screen.calendar.week.WeekContent
 import com.seom.accountbook.ui.screen.calendar.week.getWeeks
@@ -45,7 +46,10 @@ fun MonthContent(
                     firstDayOfTheWeek = daysOfWeek.first(),
                     today = today
                 ).forEach { week ->
-                    WeekContent(week = week, dayContent = dayContent)
+                    WeekContent(
+                        week = week,
+                        dayContent = dayContent
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/calendar/week/WeekContent.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/calendar/week/WeekContent.kt
@@ -3,6 +3,7 @@ package com.seom.accountbook.ui.screen.calendar.week
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.ui.screen.calendar.day.DayState
 
 @Composable
@@ -21,7 +22,9 @@ internal fun WeekContent(
             Box(
                 modifier = Modifier.fillMaxWidth(1f / (7 - index))
             ) {
-                dayContent(DayState(day))
+                dayContent(
+                    DayState(day)
+                )
             }
         }
     }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/history/HistoryScreen.kt
@@ -141,6 +141,7 @@ fun HistoryBody(
         // 수입 / 지출 tab
         HistoryTopTab(
             currentSelectedTab = currentSelectedTab,
+            histories = histories,
             onTabSelected = {
                 currentSelectedTab = currentSelectedTab xor (2.0).pow(it.type).toInt()
             },
@@ -164,6 +165,7 @@ fun HistoryBody(
 @Composable
 fun HistoryTopTab(
     currentSelectedTab: Int,
+    histories: List<HistoryModel>,
     onTabSelected: (HistoryType) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -177,14 +179,16 @@ fun HistoryTopTab(
                 .clip(RoundedCornerShape(10.dp))
         ) {
             // 수입 tab
-            HistoryType.values().forEach {
+            HistoryType.values().forEach { type ->
                 HistoryTypeItem(
-                    type = it,
-                    selected = ((2.0).pow(it.type).toInt() and currentSelectedTab) > 0,
+                    type = type,
+                    count = histories.filter { history -> type == history.type }
+                        .sumOf { it.money }.toLong(),
+                    selected = ((2.0).pow(type.type).toInt() and currentSelectedTab) > 0,
                     modifier = Modifier
                         .weight(1f)
                         .clickable {
-                            onTabSelected(it)
+                            onTabSelected(type)
                         }
                 )
             }
@@ -195,6 +199,7 @@ fun HistoryTopTab(
 @Composable
 fun HistoryTypeItem(
     type: HistoryType,
+    count: Long,
     selected: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -229,7 +234,7 @@ fun HistoryTypeItem(
         }
 
         Text(
-            text = stringResource(id = type.title),
+            text = "${stringResource(id = type.title)} ${count.toMoney()}원",
             style = MaterialTheme.typography.subtitle1,
             color = ColorPalette.White,
             modifier = Modifier.padding(

--- a/app/src/main/java/com/seom/accountbook/util/ext/IntExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/IntExtension.kt
@@ -3,4 +3,7 @@ package com.seom.accountbook.util.ext
 import java.text.DecimalFormat
 
 val formatter = DecimalFormat("#,###")
-fun Int.toMoney() = formatter.format(this)
+fun Int.toMoney(): String {
+    if (this == 0) return ""
+    return formatter.format(this)
+}

--- a/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
@@ -1,4 +1,7 @@
 package com.seom.accountbook.util.ext
 import java.text.DecimalFormat
 
-fun Long.toMoney() = formatter.format(this)
+fun Long.toMoney(): String {
+    if (this == 0L) return ""
+    else return formatter.format(this)
+}

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -43,6 +43,7 @@ fun AccountNavigationHost(
         }
         composable(route = Calendar.route) {
             CalendarScreen(
+                viewModel = viewModel(),
                 onPushNavigate = { route, argument ->
                     navController.navigateSingleTop(route, argument)
                 }


### PR DESCRIPTION
### 📌 Summary
달력 화면의 데이터를 Database와 연동하기

### 🍿 Main Changes
- 데이터베이스에서 일별 수입/지출 정보 받아오기
- 해당 월의 총 수입/지출 금액은 받아온 데이터에서 filter와 sum 메서드를 이용해서 구현
- 월 이동 시, 해당 월의 내역 정보 요청

### 🔥 UseCase
<img width="468" alt="스크린샷 2022-08-01 오후 4 44 55" src="https://user-images.githubusercontent.com/22411296/182098927-1623aef7-87af-40c8-a0aa-5d630eb9dffc.png">

### 🛠 Related Issue
Closes #29