### PR TITLE
통계 화면(graph 화면) Database와 연동하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
@@ -215,12 +215,15 @@ class AccountDao(
                 "C.${CategoryEntity.COLUMN_NAME_ID}," +
                 "C.${CategoryEntity.COLUMN_NAME_NAME}," +
                 "C.${CategoryEntity.COLUMN_NAME_COLOR}," +
-                "SUM(${AccountEntity.COLUMN_NAME_COUNT}) " +
+                "SUM(${AccountEntity.COLUMN_NAME_COUNT}) AS S " +
                 "FROM ${TABLE_NAME} A " +
                 "LEFT JOIN ${CategoryDao.TABLE_NAME} C " +
                 "ON A.${AccountEntity.COLUMN_NAME_CATEGORY} = C.${CategoryEntity.COLUMN_NAME_ID} " +
                 "WHERE A.${AccountEntity.COLUMN_NAME_TYPE} = ${HistoryType.OUTCOME.type} " +
-                "GROUP BY A.${AccountEntity.COLUMN_NAME_CATEGORY}"
+                "AND A.${AccountEntity.COLUMN_NAME_YEAR} = $year " +
+                "AND A.${AccountEntity.COLUMN_NAME_MONTH} = $month " +
+                "GROUP BY A.${AccountEntity.COLUMN_NAME_CATEGORY} " +
+                "ORDER BY S DESC"
 
         val cursor = db.rawQuery(query, null)
 

--- a/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
+++ b/app/src/main/java/com/seom/accountbook/data/local/AccountDao.kt
@@ -9,6 +9,7 @@ import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.data.entity.category.CategoryEntity
 import com.seom.accountbook.data.entity.method.MethodEntity
 import com.seom.accountbook.di.provideAppDatabase
+import com.seom.accountbook.model.graph.OutComeByCategory
 import com.seom.accountbook.model.history.HistoryModel
 import com.seom.accountbook.model.history.HistoryType
 
@@ -199,6 +200,39 @@ class AccountDao(
                         date = cursor.getInt(0),
                         count = cursor.getInt(1),
                         type = cursor.getInt(2)
+                    )
+                )
+            } while (cursor.moveToNext())
+        }
+
+        return accounts.toList()
+    }
+
+    fun getOutComeOnCategory(year: Int, month: Int): List<OutComeByCategory> {
+        val db = appDatabase.writable
+        val query = "" +
+                "SELECT " +
+                "C.${CategoryEntity.COLUMN_NAME_ID}," +
+                "C.${CategoryEntity.COLUMN_NAME_NAME}," +
+                "C.${CategoryEntity.COLUMN_NAME_COLOR}," +
+                "SUM(${AccountEntity.COLUMN_NAME_COUNT}) " +
+                "FROM ${TABLE_NAME} A " +
+                "LEFT JOIN ${CategoryDao.TABLE_NAME} C " +
+                "ON A.${AccountEntity.COLUMN_NAME_CATEGORY} = C.${CategoryEntity.COLUMN_NAME_ID} " +
+                "WHERE A.${AccountEntity.COLUMN_NAME_TYPE} = ${HistoryType.OUTCOME.type} " +
+                "GROUP BY A.${AccountEntity.COLUMN_NAME_CATEGORY}"
+
+        val cursor = db.rawQuery(query, null)
+
+        val accounts = mutableListOf<OutComeByCategory>()
+        if (cursor.moveToFirst()) {
+            do {
+                accounts.add(
+                    OutComeByCategory(
+                        id = cursor.getLong(0),
+                        name = cursor.getString(1) ?: "UnKnown",
+                        color = cursor.getLong(2) ?: 0xFFECECEC,
+                        count = cursor.getLong(3)
                     )
                 )
             } while (cursor.moveToNext())

--- a/app/src/main/java/com/seom/accountbook/data/repository/AccountRepository.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/AccountRepository.kt
@@ -3,6 +3,7 @@ package com.seom.accountbook.data.repository
 import com.seom.accountbook.data.entity.Result
 import com.seom.accountbook.data.entity.account.AccountEntity
 import com.seom.accountbook.data.entity.calendar.CalendarEntity
+import com.seom.accountbook.model.graph.OutComeByCategory
 import com.seom.accountbook.model.history.HistoryModel
 
 interface AccountRepository {
@@ -23,4 +24,7 @@ interface AccountRepository {
 
     // 일별 수입/지출 내역 가져오기
     suspend fun getAllAccountOnDate(year: Int, month: Int): Result<List<CalendarEntity>>
+
+    // 특정 월의 카테고리별 지출 내역 가져오기
+    suspend fun getOutComeOnCategory(year: Int, month: Int): Result<List<OutComeByCategory>>
 }

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.seom.accountbook.data.entity.Result
 import com.seom.accountbook.data.entity.calendar.CalendarEntity
+import com.seom.accountbook.model.graph.OutComeByCategory
 import com.seom.accountbook.model.history.HistoryModel
 
 class AccountRepositoryImpl(
@@ -80,4 +81,17 @@ class AccountRepositoryImpl(
                 Result.Error(exception.toString())
             }
         }
+
+    override suspend fun getOutComeOnCategory(
+        year: Int,
+        month: Int
+    ): Result<List<OutComeByCategory>> = withContext(ioDispatcher) {
+        try {
+            val result = accountDao.getOutComeOnCategory(year, month)
+            Result.Success(result)
+        } catch (exception: Exception) {
+            println(exception.toString())
+            Result.Error(exception.toString())
+        }
+    }
 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -13,9 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,6 +34,7 @@ import com.seom.accountbook.ui.screen.calendar.CalendarContainer
 import com.seom.accountbook.ui.screen.calendar.RowData
 import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.toMoney
+import java.time.LocalDate
 
 val mockData = listOf(
     OutComeByCategory(id = 0, name = "생활", color = 0xFF4A6CC3, count = 536460),
@@ -65,8 +64,28 @@ val mockData = listOf(
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun GraphScreen(
+    viewModel: GraphViewModel,
     onPushNavigate: (String, String) -> Unit
 ) {
+    var accounts by remember { mutableStateOf<List<OutComeByCategory>>(emptyList()) }
+
+    val observer = viewModel.graphUiState.collectAsState()
+    when (val result = observer.value) {
+        GraphUiState.UnInitialized -> {
+            val current = LocalDate.now()
+
+            val year = current.year
+            val month = current.month.value
+            viewModel.fetchData(year, month)
+        }
+        GraphUiState.Loading -> {}
+        is GraphUiState.SuccessFetch -> {
+            accounts = result.accounts
+            println(accounts)
+        }
+        is GraphUiState.Error -> {}
+    }
+
     DateAppBar(
         onDateChange = {
 

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -36,31 +36,6 @@ import com.seom.accountbook.ui.theme.ColorPalette
 import com.seom.accountbook.util.ext.toMoney
 import java.time.LocalDate
 
-val mockData = listOf(
-    OutComeByCategory(id = 0, name = "생활", color = 0xFF4A6CC3, count = 536460),
-    OutComeByCategory(
-        id = 1,
-        name = "의료/건강",
-        color = 0xFF6ED5EB,
-        count = 125300
-    ),
-    OutComeByCategory(
-        id = 2,
-        name = "쇼핑/뷰티",
-        color = 0xFF4CB8B8,
-        count = 56000
-    ),
-    OutComeByCategory(id = 3, name = "교통", color = 0xFF94D3CC, count = 45340),
-    OutComeByCategory(id = 4, name = "식비", color = 0xFF4CA1DE, count = 40540),
-    OutComeByCategory(
-        id = 5,
-        name = "문화/여가",
-        color = 0xFFD092E2,
-        count = 20800
-    ),
-    OutComeByCategory(id = 6, name = "미분류", color = 0xFF817DCE, count = 10200)
-)
-
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun GraphScreen(
@@ -81,39 +56,53 @@ fun GraphScreen(
         GraphUiState.Loading -> {}
         is GraphUiState.SuccessFetch -> {
             accounts = result.accounts
-            println(accounts)
         }
         is GraphUiState.Error -> {}
     }
 
+    val totalCount = accounts.sumOf { it.count }
+
     DateAppBar(
         onDateChange = {
-
+            viewModel.fetchData(it.year, it.month.value)
         },
         children = {
-            Column {
+            Column(modifier = Modifier.fillMaxSize()) {
                 Divider(
                     color = ColorPalette.Purple,
                     thickness = 1.dp
                 )
-                TopRow(totalCount = 834640)
+                TopRow(totalCount = totalCount)
                 Divider(
                     color = ColorPalette.LightPurple,
                     thickness = 1.dp
                 )
-                Spacer(modifier = Modifier.height(24.dp))
-                CircleGraphByRate(
-                    date = mockData,
-                    totalCount = 834640,
-                    modifier = Modifier
-                        .height(254.dp)
-                        .fillMaxWidth()
-                )
-                Spacer(modifier = Modifier.height(24.dp))
-                CategoryList(
-                    data = mockData,
-                    totalCount = 834640,
-                    onItemClick = { onPushNavigate(Detail.route, it.toString()) })
+                Box(modifier = Modifier.fillMaxSize()) {
+                    if (accounts.isNullOrEmpty()) {
+                        Text(
+                            text = "내역이 없습니다.",
+                            style = MaterialTheme.typography.subtitle1.copy(color = ColorPalette.Purple),
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    } else {
+                        Column() {
+                            Spacer(modifier = Modifier.height(24.dp))
+                            CircleGraphByRate(
+                                date = accounts,
+                                totalCount = totalCount,
+                                modifier = Modifier
+                                    .height(254.dp)
+                                    .fillMaxWidth()
+                            )
+                            Spacer(modifier = Modifier.height(24.dp))
+                            CategoryList(
+                                data = accounts,
+                                totalCount = totalCount,
+                                onItemClick = { onPushNavigate(Detail.route, it.toString()) })
+
+                        }
+                    }
+                }
             }
         }
     )
@@ -121,7 +110,7 @@ fun GraphScreen(
 
 @Composable
 fun TopRow(
-    totalCount: Int
+    totalCount: Long
 ) {
     Row(
         modifier = Modifier
@@ -135,13 +124,13 @@ fun TopRow(
             style = MaterialTheme.typography.caption.copy(color = ColorPalette.Purple)
         )
         Text(
-            text = totalCount.toMoney(),
+            text = "${totalCount.toMoney()} 원",
             style = MaterialTheme.typography.caption.copy(color = ColorPalette.Red)
         )
     }
 }
 
-private const val DividerLengthInDegrees = 1.8f
+private const val DividerLengthInDegrees = 0f
 
 private enum class AnimatedCircleProgress { START, END }
 
@@ -185,8 +174,8 @@ fun CircleGraphByRate(
         date.forEachIndexed { index, rate ->
             val sweep = (rate.count / totalCount.toFloat()) * angleOffset
             drawArc(
-                color = Color(rate.color),
-                startAngle = startAngle + DividerLengthInDegrees / 2,
+                color = Color(if(rate.color == 0L) 0xFF2E2E2E else rate.color),
+                startAngle = startAngle + DividerLengthInDegrees,
                 sweepAngle = sweep - DividerLengthInDegrees,
                 topLeft = topLeft,
                 size = size,
@@ -250,7 +239,7 @@ fun CategoryOutComeItem(
                     modifier = Modifier
                         .widthIn(56.dp)
                         .clip(RoundedCornerShape(999.dp))
-                        .background(Color(data.color))
+                        .background(Color(if (data.color == 0L) 0xFF2E2E2E else data.color))
                         .padding(start = 8.dp, top = 4.dp, end = 8.dp, bottom = 4.dp),
                     textAlign = TextAlign.Center
                 )

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
@@ -1,0 +1,47 @@
+package com.seom.accountbook.ui.screen.graph
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.data.entity.calendar.CalendarEntity
+import com.seom.accountbook.data.repository.AccountRepository
+import com.seom.accountbook.data.repository.impl.AccountRepositoryImpl
+import com.seom.accountbook.model.graph.OutComeByCategory
+import com.seom.accountbook.ui.screen.calendar.CalendarUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class GraphViewModel(
+    private val accountRepository: AccountRepository = AccountRepositoryImpl()
+) : ViewModel() {
+    private val _graphUiState = MutableStateFlow<GraphUiState>(GraphUiState.UnInitialized)
+    val graphUiState: StateFlow<GraphUiState>
+        get() = _graphUiState
+
+    fun fetchData(year: Int, month: Int) = viewModelScope.launch {
+        _graphUiState.value = GraphUiState.Loading
+        when (val result = accountRepository.getOutComeOnCategory(year, month)) {
+            is Result.Error -> _graphUiState.value =
+                GraphUiState.Error(R.string.error_history_get)
+            is Result.Success -> _graphUiState.value =
+                GraphUiState.SuccessFetch(result.data)
+        }
+    }
+}
+
+sealed interface GraphUiState {
+    object UnInitialized : GraphUiState
+    object Loading : GraphUiState
+
+    data class SuccessFetch(
+        val accounts: List<OutComeByCategory>
+    ) : GraphUiState
+
+    data class Error(
+        @StringRes
+        val errorMsg: Int
+    ) : GraphUiState
+}

--- a/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
+++ b/app/src/main/java/com/seom/accountbook/util/ext/LongExtension.kt
@@ -1,7 +1,4 @@
 package com.seom.accountbook.util.ext
 import java.text.DecimalFormat
 
-fun Long.toMoney(): String {
-    if (this == 0L) return ""
-    else return formatter.format(this)
-}
+fun Long.toMoney(): String = formatter.format(this)

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -51,6 +51,7 @@ fun AccountNavigationHost(
         }
         composable(route = Graph.route) {
             GraphScreen(
+                viewModel = viewModel(),
                 onPushNavigate = { route, argument ->
                     navController.navigateSingleTop(route, argument)
                 }


### PR DESCRIPTION
### 📌 Summary
통계 화면의 그래프를 위한 데이터를 Database에서 받아오기

### 🍿 Main Changes
- 데이터베이스에서 특정 월의 카테고리별 지출 내역 정보 받아오기
- 해당 데이터 화면에 보여주기
- 월 이동 시, 해당 월의 내역 정보 요청

### 🔥 UseCase
<img width="468" alt="스크린샷 2022-08-01 오후 5 45 12" src="https://user-images.githubusercontent.com/22411296/182109962-9866db71-a194-4d90-a437-39225d5b412c.png">

### 🛠 Related Issue
Closes #31