### PR TITLE
상세 화면(detail 화면) Database와 연동하기

### DIFF
--- a/app/src/main/java/com/seom/accountbook/AccountActivity.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountActivity.kt
@@ -38,9 +38,9 @@ fun AccountApp() {
     val currentBackStack by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStack?.destination
     val currentScreen =
-        allScreens.find { it.route == currentDestination?.route } ?: History
+        allScreens.find { currentDestination?.route?.startsWith(it.route) ?: false } ?: History
 
-    println(currentScreen.route)
+    println(currentDestination?.route)
     AccountBookTheme() {
         Scaffold(
             bottomBar = {

--- a/app/src/main/java/com/seom/accountbook/AccountDestination.kt
+++ b/app/src/main/java/com/seom/accountbook/AccountDestination.kt
@@ -51,9 +51,13 @@ object Detail : AccountDestination {
     override val title = "상세"
     override val group = "graph"
     const val categoryIdArgs = "category_id"
-    val routeWithArgs = "${Detail.route}/{${categoryIdArgs}}"
+    const val yearArgs = "year"
+    const val monthArgs = "month"
+    val routeWithArgs = "${route}/{${categoryIdArgs}},{${yearArgs}},{${monthArgs}}"
     val arguments = listOf(
-        navArgument(categoryIdArgs) { type = NavType.StringType }
+        navArgument(categoryIdArgs) { type = NavType.StringType },
+        navArgument(yearArgs) { type = NavType.IntType },
+        navArgument(monthArgs) { type = NavType.IntType }
     )
 }
 

--- a/app/src/main/java/com/seom/accountbook/data/repository/AccountRepository.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/AccountRepository.kt
@@ -4,6 +4,7 @@ import com.seom.accountbook.data.entity.Result
 import com.seom.accountbook.data.entity.account.AccountEntity
 import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.model.graph.OutComeByCategory
+import com.seom.accountbook.model.graph.OutComeByMonth
 import com.seom.accountbook.model.history.HistoryModel
 
 interface AccountRepository {
@@ -27,4 +28,10 @@ interface AccountRepository {
 
     // 특정 월의 카테고리별 지출 내역 가져오기
     suspend fun getOutComeOnCategory(year: Int, month: Int): Result<List<OutComeByCategory>>
+
+    // 특정 카테고리의 6개월 이내 월별 지출 총액 가져오기
+    suspend fun getOutComeOnMonth(categoryId: Long, year: Int, month: Int): Result<List<OutComeByMonth>>
+
+    // 특정 카테고리의 6개월 이내 일별 지출 내역 가져오기
+    suspend fun getDetailOutComeOnCategory(categoryId: Long, year: Int, month: Int): Result<List<HistoryModel>>
 }

--- a/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/accountbook/data/repository/impl/AccountRepositoryImpl.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withContext
 import com.seom.accountbook.data.entity.Result
 import com.seom.accountbook.data.entity.calendar.CalendarEntity
 import com.seom.accountbook.model.graph.OutComeByCategory
+import com.seom.accountbook.model.graph.OutComeByMonth
 import com.seom.accountbook.model.history.HistoryModel
 
 class AccountRepositoryImpl(
@@ -88,6 +89,34 @@ class AccountRepositoryImpl(
     ): Result<List<OutComeByCategory>> = withContext(ioDispatcher) {
         try {
             val result = accountDao.getOutComeOnCategory(year, month)
+            Result.Success(result)
+        } catch (exception: Exception) {
+            println(exception.toString())
+            Result.Error(exception.toString())
+        }
+    }
+
+    override suspend fun getOutComeOnMonth(
+        categoryId: Long,
+        year: Int,
+        month: Int
+    ): Result<List<OutComeByMonth>> = withContext(ioDispatcher) {
+        try {
+            val result = accountDao.getOutComeOnMonth(categoryId, year, month)
+            Result.Success(result)
+        } catch (exception: Exception) {
+            println(exception.toString())
+            Result.Error(exception.toString())
+        }
+    }
+
+    override suspend fun getDetailOutComeOnCategory(
+        categoryId: Long,
+        year: Int,
+        month: Int
+    ): Result<List<HistoryModel>>  = withContext(ioDispatcher) {
+        try {
+            val result = accountDao.getDetailOutComeOnCategory(categoryId, year, month)
             Result.Success(result)
         } catch (exception: Exception) {
             println(exception.toString())

--- a/app/src/main/java/com/seom/accountbook/model/detail/DetailOutComeOnCategory.kt
+++ b/app/src/main/java/com/seom/accountbook/model/detail/DetailOutComeOnCategory.kt
@@ -1,0 +1,10 @@
+package com.seom.accountbook.model.detail
+
+import com.seom.accountbook.model.graph.OutComeByMonth
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.model.history.HistoryModel
+
+data class DetailOutComeOnCategory(
+    val outComeOnMonth: Result<List<OutComeByMonth>>,
+    val accounts: Result<List<HistoryModel>>
+)

--- a/app/src/main/java/com/seom/accountbook/model/graph/OutComeByMonth.kt
+++ b/app/src/main/java/com/seom/accountbook/model/graph/OutComeByMonth.kt
@@ -3,8 +3,6 @@ package com.seom.accountbook.model.graph
 import com.seom.accountbook.model.BaseCount
 
 data class OutComeByMonth(
-    override val id: Long,
-    override val count: Long, // 월별 지출
-    override val color: Long,
-    override val name: String // 월
-) : BaseCount
+    val count: Long, // 월별 지출
+    val name: String // 월
+)

--- a/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/detail/DetailViewModel.kt
@@ -1,0 +1,57 @@
+package com.seom.accountbook.ui.screen.detail
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.seom.accountbook.R
+import com.seom.accountbook.data.entity.Result
+import com.seom.accountbook.model.graph.OutComeByCategory
+import com.seom.accountbook.model.graph.OutComeByMonth
+import com.seom.accountbook.model.history.HistoryModel
+import com.seom.accountbook.ui.screen.graph.GraphUiState
+import com.seom.accountbook.usecase.GetDetailOutComeOnCategoryUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class DetailViewModel(
+    private val getDetailOutComeOnCategory: GetDetailOutComeOnCategoryUseCase = GetDetailOutComeOnCategoryUseCase()
+): ViewModel() {
+    private val _detailUiState = MutableStateFlow<DetailUiState>(DetailUiState.UnInitialized)
+    val detailUiState: StateFlow<DetailUiState>
+        get() = _detailUiState
+
+    fun fetchData(categoryId: Long, year: Int, month: Int) = viewModelScope.launch {
+        _detailUiState.value = DetailUiState.Loading
+        println("************")
+        val result = getDetailOutComeOnCategory(categoryId,year,month)
+
+        val outComeByMonth = when(val data = result.outComeOnMonth) {
+            is Result.Error -> emptyList()
+            is Result.Success -> data.data
+        }
+        val accounts = when(val data = result.accounts) {
+            is Result.Error -> emptyList()
+            is Result.Success -> data.data
+        }
+        _detailUiState.value = DetailUiState.SuccessFetch(
+            outComeByMonth = outComeByMonth,
+            accounts = accounts
+        )
+    }
+}
+
+sealed interface DetailUiState {
+    object UnInitialized : DetailUiState
+    object Loading : DetailUiState
+
+    data class SuccessFetch(
+        val outComeByMonth: List<OutComeByMonth>,
+        val accounts: List<HistoryModel>
+    ) : DetailUiState
+
+    data class Error(
+        @StringRes
+        val errorMsg: Int
+    ) : DetailUiState
+}

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphScreen.kt
@@ -98,8 +98,12 @@ fun GraphScreen(
                             CategoryList(
                                 data = accounts,
                                 totalCount = totalCount,
-                                onItemClick = { onPushNavigate(Detail.route, it.toString()) })
-
+                                onItemClick = {
+                                    onPushNavigate(
+                                        Detail.route,
+                                        "$it,${viewModel.currentYear},${viewModel.currentMonth}"
+                                    )
+                                })
                         }
                     }
                 }

--- a/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
+++ b/app/src/main/java/com/seom/accountbook/ui/screen/graph/GraphViewModel.kt
@@ -21,13 +21,20 @@ class GraphViewModel(
     val graphUiState: StateFlow<GraphUiState>
         get() = _graphUiState
 
+    var currentYear = 0
+    var currentMonth = 0
+
     fun fetchData(year: Int, month: Int) = viewModelScope.launch {
         _graphUiState.value = GraphUiState.Loading
         when (val result = accountRepository.getOutComeOnCategory(year, month)) {
             is Result.Error -> _graphUiState.value =
                 GraphUiState.Error(R.string.error_history_get)
-            is Result.Success -> _graphUiState.value =
-                GraphUiState.SuccessFetch(result.data)
+            is Result.Success -> {
+                currentYear = year
+                currentMonth = month
+                _graphUiState.value =
+                    GraphUiState.SuccessFetch(result.data)
+            }
         }
     }
 }

--- a/app/src/main/java/com/seom/accountbook/usecase/GetDetailOutComeOnCategoryUseCase.kt
+++ b/app/src/main/java/com/seom/accountbook/usecase/GetDetailOutComeOnCategoryUseCase.kt
@@ -1,0 +1,24 @@
+package com.seom.accountbook.usecase
+
+import com.seom.accountbook.data.repository.AccountRepository
+import com.seom.accountbook.data.repository.impl.AccountRepositoryImpl
+import com.seom.accountbook.model.detail.DetailOutComeOnCategory
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+class GetDetailOutComeOnCategoryUseCase(
+    private val accountRepository: AccountRepository = AccountRepositoryImpl()
+) {
+    suspend operator fun invoke(categoryId: Long, year: Int, month: Int): DetailOutComeOnCategory =
+        coroutineScope {
+            val outComeOnMonth =
+                async { accountRepository.getOutComeOnMonth(categoryId, year, month) }
+            val accounts =
+                async { accountRepository.getDetailOutComeOnCategory(categoryId, year, month) }
+
+            DetailOutComeOnCategory(
+                outComeOnMonth = outComeOnMonth.await(),
+                accounts = accounts.await()
+            )
+        }
+}

--- a/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
+++ b/app/src/main/java/com/seom/accountbook/util/route/AccountNavigation.kt
@@ -92,11 +92,19 @@ fun AccountNavigationHost(
             route = Detail.routeWithArgs,
             arguments = Detail.arguments
         ) { navBackStackEntry ->
+            val year = navBackStackEntry.arguments?.getInt(Detail.yearArgs)
+            val month = navBackStackEntry.arguments?.getInt(Detail.monthArgs)
             val categoryId = navBackStackEntry.arguments?.getString(Detail.categoryIdArgs)
-            DetailScreen(
-                categoryId = categoryId,
-                onBackButtonPressed = { navController.popBackStack() }
-            )
+
+            if (year != null && month != null && categoryId != null) {
+                DetailScreen(
+                    year = year,
+                    month = month,
+                    categoryId = categoryId,
+                    viewModel = viewModel(),
+                    onBackButtonPressed = { navController.popBackStack() }
+                )
+            }
         }
         // 결제 수단 새로 추가
         composable(
@@ -154,7 +162,7 @@ fun AccountNavigationHost(
 }
 
 fun NavController.navigateSingleTop(route: String, argument: String = "") {
-    navigate("$route${if (argument.isNullOrBlank()) "" else "/${argument}"}") {
+    navigate("$route${if (argument.isBlank()) "" else "/${argument}"}") {
         // back button 클릭 시에는 이전 tab 으로 이도할 수 있도록 하기 위해 popUpTo는 지정하지 않음
         launchSingleTop = true
     }


### PR DESCRIPTION
### 📌 Summary
상세 화면의 그래프를 위한 데이터를 Database에서 받아와 화면에 보여주기
- 최근 6개월 간 특정 카테고리의 지출 내역

### 🍿 Main Changes
- 상단의 월별 총 지출 내역부분과 하단 일별 지출 내역을 별도의 query로 해서 받아옵니다.
- 사용자가 통계화면(graph 화면)에서 선택한 연도/월을 기준으로 6개월 이전의 데이터를 보여줍니다.

### 🔥 UseCase
<img width="467" alt="스크린샷 2022-08-02 오전 12 32 59" src="https://user-images.githubusercontent.com/22411296/182185627-c3dc98c8-c665-49b4-87d0-dc233ef6d16f.png">

### 🛠 Related Issue
Closes #33